### PR TITLE
Fix dynect event names

### DIFF
--- a/bin/alert-dynect.py
+++ b/bin/alert-dynect.py
@@ -23,7 +23,7 @@ import socket
 from dynect.DynectDNS import DynectRest
 
 __program__ = 'alert-dynect'
-__version__ = '1.1.3'
+__version__ = '1.1.4'
 
 BROKER_LIST  = [('localhost', 61613)] # list of brokers for failover
 ALERT_QUEUE  = '/queue/alerts'

--- a/docs/RELEASE-NOTES.txt
+++ b/docs/RELEASE-NOTES.txt
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+Alerta version 1.2.8
+--------------------
+* Make alert-dynect.py use the same event names so that events correlate
+
 Alerta version 1.2.7
 --------------------
 


### PR DESCRIPTION
This makes the dynect event names be one of two which should mean events will correlate and disappear from the dashboard.
