### PR TITLE
Ganglia poller: Untested rewrite to try to create more maintainable code

### DIFF
--- a/alerta/ganglia/daemon.py
+++ b/alerta/ganglia/daemon.py
@@ -330,9 +330,13 @@ class GangliaDaemon(Daemon):
         try:
             r = urllib2.urlopen(url, None, 15)
             if r.getcode():
-                response = json.loads(r.read())['response']
-                if not response['status'] == 'error':
-                    LOG.info('Retrieved %s matching metrics in %ss', response['total'], response['time'])
+                data = json.loads(r.read())
+
+                if 'response' in data:
+                    response = data['response']
+
+                    if not response['status'] == 'error':
+                        LOG.info('Retrieved %s matching metrics in %ss', response['total'], response['time'])
 
                     return response['metrics']
 


### PR DESCRIPTION
This change tries to do a couple of things. It pulls references to CONF up into constructors or keyword arguments to try and make it possible to override them in test circumstances.

It switches explicitly indexed loops to use enumerate and it changes the query parameter generation to use a for comprehension.

It compiles but I haven't tested. This aims to be like for like.
