### PR TITLE
Dashboard: Block an alerts refresh if an alert is open

### DIFF
--- a/dashboard/v2/assets/js/console.js
+++ b/dashboard/v2/assets/js/console.js
@@ -127,6 +127,10 @@ function date2str(datetime) {
 
 $.fn.dataTableExt.oApi.fnReloadAjax = function ( oSettings, sNewSource, fnCallback, bStandingRedraw )
 {
+    var openRows = $("#alerts tr").filter(function () { return oTable.fnIsOpen(this); });
+
+    if(openRows.length > 0) { return; }
+
     if ( typeof sNewSource != 'undefined' && sNewSource != null ) {
         oSettings.sAjaxSource = sNewSource;
     }


### PR DESCRIPTION
This is a relatively hacky way of solving the refresh issue where open alerts are closed if the dashboard auto refreshes.

This change terminates the auto-refresh if one of the rows is open. Once the row is closed then the dashboard with auto-refresh normally.
