### PR TITLE
Dashboard: Change default filtering

### DIFF
--- a/dashboard/v2/assets/js/console.js
+++ b/dashboard/v2/assets/js/console.js
@@ -285,7 +285,8 @@ function updateAlertsTable(env_filter, asiFilters) {
             { "bVisible": false }
         ],
         "aaSorting": [
-            [2, 'desc']
+            [0, 'asc'],
+            [2, 'asc']
         ],
     });
 


### PR DESCRIPTION
The default filter is now by severity, then alert date (oldest first).
