### PR TITLE
Allow all attribute variables to be updated by parser

### DIFF
--- a/alerta/common/alert.py
+++ b/alerta/common/alert.py
@@ -296,7 +296,7 @@ class Alert(object):
                     LOG.debug('Loading parser %s', c['parser'])
 
                     context = kwargs
-                    context.update(self.get_body())
+                    context.update(self.__dict__)
 
                     try:
                         exec(open('%s/%s.py' % (CONF.parser_dir, c['parser']))) in globals(), context
@@ -305,7 +305,7 @@ class Alert(object):
                         LOG.warning('Parser %s failed: %s', c['parser'], e)
 
                     for k, v in context.iteritems():
-                        if k in ATTRIBUTES:
+                        if hasattr(self, k):
                             setattr(self, k, v)
 
                     if 'suppress' in context:
@@ -337,7 +337,7 @@ class Alert(object):
             if self.tags is not None:
                 self.tags[:] = [t.replace(k, v) for t in self.tags]
             if self.correlate is not None:
-                self.correlate = [c.replace(k, v) for c in self.correlate]
+                self.correlate[:] = [c.replace(k, v) for c in self.correlate]
             if self.threshold_info is not None:
                 self.threshold_info = self.threshold_info.replace(k, v)
             if self.summary is not None:


### PR DESCRIPTION
Some combination of the bugs fixed by this pull request combined to prevent some attributes from being updated by an alert parser. For example, `more_info` and `threshold_info`.
