### PR TITLE
Dashboard: Persist the datatable settings

### DIFF
--- a/dashboard/v2/assets/js/console.js
+++ b/dashboard/v2/assets/js/console.js
@@ -279,6 +279,7 @@ function updateAlertsTable(env_filter, asiFilters) {
         "bSort": true,
         "bPaginate": true,
         "bDeferRender": true,
+        "bStateSave" : true,
         "sAjaxSource": 'http://' + API_HOST + '/alerta/api/v2/alerts?' + gEnvFilter + filter + status + limit + from,
         "fnRowCallback": function (nRow, aData, iDisplayIndex, iDisplayIndexFull) {
             nRow.className = 'severity-' + aData[0] + ' status-' + aData[1];


### PR DESCRIPTION
This simply switches on state saving for datatables so things like the number of default rows persists between refreshes.
