### PR TITLE
Housekeeping Endpoint and setup.py

### DIFF
--- a/alerta/management/views.py
+++ b/alerta/management/views.py
@@ -128,7 +128,7 @@ def health_check():
     return 'OK'
 
 
-@mgmt.route('/management/housekeeping', methods=['OPTIONS', 'GET'])
+@mgmt.route('/management/housekeeping', methods=['OPTIONS', 'GET', 'POST'])
 @cross_origin()
 @permission('admin:management')
 def housekeeping():
@@ -143,9 +143,9 @@ def housekeeping():
 
     try:
         Alert.housekeeping(expired_threshold, info_threshold)
-        return 'OK'
+        return jsonify(status='ok')
     except Exception as e:
-        return 'HOUSEKEEPING FAILED: %s' % e, 503
+        raise ApiError('HOUSEKEEPING FAILED: %s' % e, 503)
 
 
 @mgmt.route('/management/status', methods=['OPTIONS', 'GET'])

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,10 @@ from datetime import datetime
 
 import setuptools
 
-with open('VERSION') as f:
-    version = f.read().strip()
 
-with open('README.md') as f:
-    readme = f.read()
+def read(filename):
+    return open(os.path.join(os.path.dirname(__file__), filename)).read()
+
 
 try:
     with open('alerta/build.py', 'w') as f:
@@ -29,9 +28,9 @@ except Exception:
 
 setuptools.setup(
     name='alerta-server',
-    version=version,
+    version=read('VERSION'),
     description='Alerta server WSGI application',
-    long_description=readme,
+    long_description=read('README.md'),
     url='https://github.com/guardian/alerta',
     license='Apache License 2.0',
     author='Nick Satterly',


### PR DESCRIPTION
I've reworked /management/housekeeping to send JSON responses. See also alerta/python-alerta-client/pull/118

I've also put POST as an allowed method. I think that POST is more correct than GET in this case. This is a minor concern because anyone calling this endpoint is likely to be in full control of their environment. I've left GET there for backwards compatibility.

I've also made some minor modifications to setup.py because I was seeing failures installing from the sdist locally.

All of this tested with Python 3.5 on Debian 9.