### PR TITLE
Add admin commands to alertad server script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ install:
   - "pip install ."
   - "pip install -r requirements.txt"
 
-script: nosetests tests/*
+script: nosetests --verbosity=3 tests/*

--- a/alerta/commands.py
+++ b/alerta/commands.py
@@ -19,6 +19,7 @@ def cli():
 @cli.command('key', short_help='Create admin API keys')
 @with_appcontext
 def key():
+    """Create admin APi keys."""
     db.get_db()  # init db on global app context
     for admin in current_app.config['ADMIN_USERS']:
         key = ApiKey(
@@ -39,6 +40,7 @@ def key():
 @click.password_option()
 @with_appcontext
 def user(password):
+    """Create admin users."""
     db.get_db()  # init db on global app context
     for admin in current_app.config['ADMIN_USERS']:
         user = User(

--- a/alerta/commands.py
+++ b/alerta/commands.py
@@ -1,12 +1,14 @@
 
 import sys
-import click
 
+import click
 from flask import current_app
 from flask.cli import FlaskGroup, with_appcontext
 
 from alerta.app import create_app, db
+from alerta.auth.utils import generate_password_hash
 from alerta.models.key import ApiKey
+from alerta.models.user import User
 
 
 @click.group(cls=FlaskGroup, create_app=create_app)
@@ -14,10 +16,10 @@ def cli():
     pass
 
 
-@cli.command()
+@cli.command('key', short_help='Create admin API keys')
 @with_appcontext
 def key():
-    db.get_db()
+    db.get_db()  # init db on global app context
     for admin in current_app.config['ADMIN_USERS']:
         key = ApiKey(
             user=admin,
@@ -32,12 +34,27 @@ def key():
             sys.exit(1)
         click.echo('{} {}'.format(key.key, key.user))
 
-# @cli.command()
-# @with_appcontext
-# # @click.option('--coverage/--no-coverage', default=False, help='aaa')
-# # def test(coverage=False):
-# def test():
-#     click.echo('test')
+
+@cli.command('user', short_help='Create admin users')
+@click.password_option()
+@with_appcontext
+def user(password):
+    db.get_db()  # init db on global app context
+    for admin in current_app.config['ADMIN_USERS']:
+        user = User(
+            name=admin,
+            email=admin,
+            password=generate_password_hash(password),
+            roles=None,
+            text='Admin user created by alertad script',
+            email_verified=True
+        )
+        try:
+            user = user.create()
+        except Exception as e:
+            click.echo('ERROR: {}'.format(e))
+            sys.exit(1)
+        click.echo('{} {}'.format(user.id, user.name))
 
 
 if __name__ == '__main__':

--- a/alerta/commands.py
+++ b/alerta/commands.py
@@ -20,7 +20,6 @@ def cli():
 @with_appcontext
 def key():
     """Create admin APi keys."""
-    db.get_db()  # init db on global app context
     for admin in current_app.config['ADMIN_USERS']:
         key = ApiKey(
             user=admin,
@@ -29,11 +28,12 @@ def key():
             expire_time=None
         )
         try:
+            db.get_db()  # init db on global app context
             key = key.create()
         except Exception as e:
             click.echo('ERROR: {}'.format(e))
-            sys.exit(1)
-        click.echo('{} {}'.format(key.key, key.user))
+        else:
+            click.echo('{} {}'.format(key.key, key.user))
 
 
 @cli.command('user', short_help='Create admin users')
@@ -41,7 +41,6 @@ def key():
 @with_appcontext
 def user(password):
     """Create admin users."""
-    db.get_db()  # init db on global app context
     for admin in current_app.config['ADMIN_USERS']:
         user = User(
             name=admin,
@@ -52,11 +51,12 @@ def user(password):
             email_verified=True
         )
         try:
+            db.get_db()  # init db on global app context
             user = user.create()
         except Exception as e:
             click.echo('ERROR: {}'.format(e))
-            sys.exit(1)
-        click.echo('{} {}'.format(user.id, user.name))
+        else:
+            click.echo('{} {}'.format(user.id, user.name))
 
 
 if __name__ == '__main__':

--- a/alerta/commands.py
+++ b/alerta/commands.py
@@ -1,16 +1,44 @@
 
+import sys
 import click
-from flask.cli import FlaskGroup
+
+from flask import current_app
+from flask.cli import FlaskGroup, with_appcontext
+
+from alerta.app import create_app, db
+from alerta.models.key import ApiKey
 
 
-def make_app(info):
-    from alerta.app import create_app
-    return create_app()
-
-
-@click.group(cls=FlaskGroup, create_app=make_app)
+@click.group(cls=FlaskGroup, create_app=create_app)
 def cli():
-    """This is a development script for the Alerta server."""
+    pass
+
+
+@cli.command()
+@with_appcontext
+def key():
+    db.get_db()
+    for admin in current_app.config['ADMIN_USERS']:
+        key = ApiKey(
+            user=admin,
+            scopes=['admin', 'write', 'read'],
+            text='Admin key created by alertad script',
+            expire_time=None
+        )
+        try:
+            key = key.create()
+        except Exception as e:
+            click.echo('ERROR: {}'.format(e))
+            sys.exit(1)
+        click.echo('{} {}'.format(key.key, key.user))
+
+# @cli.command()
+# @with_appcontext
+# # @click.option('--coverage/--no-coverage', default=False, help='aaa')
+# # def test(coverage=False):
+# def test():
+#     click.echo('test')
+
 
 if __name__ == '__main__':
     cli()

--- a/alerta/commands.py
+++ b/alerta/commands.py
@@ -19,7 +19,7 @@ def cli():
 @click.option('--all', is_flag=True, help='Create API keys for all admins')
 @with_appcontext
 def key(username, all):
-    """Create an admin APi key."""
+    """Create an admin API key."""
     if username and username not in current_app.config['ADMIN_USERS']:
         raise click.UsageError('User {} not an admin'.format(username))
 
@@ -48,7 +48,7 @@ def key(username, all):
 @cli.command('keys', short_help='List admin API keys')
 @with_appcontext
 def keys():
-    """List admin APi keys."""
+    """List admin API keys."""
     for admin in current_app.config['ADMIN_USERS']:
         try:
             db.get_db()  # init db on global app context
@@ -69,6 +69,8 @@ def user(username, password, all):
     """Create admin users."""
     if username and username not in current_app.config['ADMIN_USERS']:
         raise click.UsageError('User {} not an admin'.format(username))
+    if not username and not all:
+        raise click.UsageError('Missing option "--username".')
 
     def create_user(admin):
         user = User(

--- a/alerta/database/base.py
+++ b/alerta/database/base.py
@@ -45,8 +45,8 @@ class Database(Base):
 
         self.create_engine(app, uri=app.config['DATABASE_URL'], dbname=app.config['DATABASE_NAME'])
 
-        app.before_request(self.before_request)
-        app.teardown_request(self.teardown_request)
+        app.before_request(self.get_db)
+        app.teardown_request(self.teardown_db)
 
     def create_engine(self, app, uri, dbname=None):
         raise NotImplementedError('Database engine has no create_engine() method')
@@ -72,13 +72,10 @@ class Database(Base):
     def destroy(self):
         raise NotImplementedError('Database engine has no destroy() method')
 
-    def before_request(self):
+    def get_db(self):
         g.db = self.connect()
 
-    def after_request(self):
-        pass
-
-    def teardown_request(self, exc):
+    def teardown_db(self, exc):
         db = getattr(g, 'db', None)
         if db is not None:
             self.close()


### PR DESCRIPTION
Add admin commands to `alertad` to create admin users and admin API keys when run on the Alerta server...
```
$ alertad --help
Usage: alertad [OPTIONS] COMMAND [ARGS]...

Options:
  --version  Show the flask version
  --help     Show this message and exit.

Commands:
  key     Create an admin API key
  keys    List admin API keys
  routes  Show the routes for the app.
  run     Runs a development server.
  shell   Runs a shell in the app context.
  user    Create admin user
  users   List admin users
```

The `user` command will create the admin user for an individual admin defined in the `ADMIN_USERS` server settings or all admins (if `--all` used) ...
```
$ alertad user --username admin@alerta.io
Password: ******
Repeat for confirmation: ******
30d78760-5008-4188-b1a7-ccb48390a665 admin@alerta.io
```
**Note: All users will get the same password so they should change them on first logon.**

The `key` command will create the admin API key for an individual admin defined in the `ADMIN_USERS` server settings or all admins (if `--all` used) ...
```
$ alertad key --username admin@alerta.io
cNfzDBpJBSDpriKiXG30_4h8VzB5Aa08GiEqYmXI admin@alerta.io
```

The `users` and `keys` commands will list all admin users and all admin API keys owned by those admins.

```
$ alertad users
30d78760-5008-4188-b1a7-ccb48390a665 admin@alerta.io
c24ff0a9-e45d-4760-bf32-e97cd8207309 nfsatterly@gmail.com
9d3c1e80-9674-427d-9ab5-75327c0e1a7a foo@foobar.com
```

```
$ alertad keys
oSr-2xXwb4pg_dfa3oHIx5tfNigz0mash4nVXddJ admin@alerta.io
cNfzDBpJBSDpriKiXG30_4h8VzB5Aa08GiEqYmXI admin@alerta.io
C4UbLUcKSzJ9jkQLKb2Yw_MHxUnf9vMXkt_gtwhO nfsatterly@gmail.com
txm-xqwD_Xd8MZK4yFFP37L2hlZvnUpN-SMNa5ZC foo@foobar.com
```

This follows on from a suggestion by @mmulqueen

>I was thinking that perhaps we could add a utility that ships with alertad, let's call it alertad-manager for now. It would directly call the Python code that alertad uses and have at least the following commands: create user (for initial setup), update user (for password resets), get or create admin key for user. This would mean you could always get into a state where you could make any remaining changes either using the API directly or through the existing alerta CLI utility. Of course, you'd only be able to run this on the host, but means you can rely on the existing trust you have for authorised users of the server to secure it.
Of course, this means that someone with access to the server, who can run alertad-manager and gain access. I don't think this is a vulnerability though because the administrator can easily restrict who can execute alertad-manager. This probably isn't much difference to the status quo because you already have to take action to prevent /etc/alertad.conf from being readable and exposing the database credentials. I think it's fine to just mention this somewhere in the docs. So in my environment, I'm running alertad under an "alerta" system user and /etc/alertad.conf is owned by alerta with 0400 privs and I'd set up alertad-manage. This should already stop another user from running alertad-manager because it wouldn't be able to get into the database.
Of course, we don't have to have a separate utility, we could put the commands into alertad instead, just feels a bit cleaner to me to have them separately.