### PR TITLE
Fix alertad CLI ScriptInfo bug

### DIFF
--- a/alerta/commands.py
+++ b/alerta/commands.py
@@ -3,13 +3,18 @@ import click
 from flask import current_app
 from flask.cli import FlaskGroup, with_appcontext
 
-from alerta.app import create_app, db
+from alerta.app import db
 from alerta.auth.utils import generate_password_hash
 from alerta.models.key import ApiKey
 from alerta.models.user import User
 
 
-@click.group(cls=FlaskGroup, create_app=create_app)
+def _create_app(info):
+    from alerta.app import create_app
+    return create_app()
+
+
+@click.group(cls=FlaskGroup, create_app=_create_app)
 def cli():
     pass
 


### PR DESCRIPTION
```
$ alertad run --port 8080 --with-threads
Traceback (most recent call last):
  File "/Users/nsatterl/.virtualenvs/alerta506/bin/alertad", line 11, in <module>
    sys.exit(cli())
  File "/Users/nsatterl/.virtualenvs/alerta506/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/nsatterl/.virtualenvs/alerta506/lib/python3.6/site-packages/flask/cli.py", line 380, in main
    return AppGroup.main(self, *args, **kwargs)
  File "/Users/nsatterl/.virtualenvs/alerta506/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/nsatterl/.virtualenvs/alerta506/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/nsatterl/.virtualenvs/alerta506/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/nsatterl/.virtualenvs/alerta506/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/nsatterl/.virtualenvs/alerta506/lib/python3.6/site-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args[1:], **kwargs)
  File "/Users/nsatterl/.virtualenvs/alerta506/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/nsatterl/.virtualenvs/alerta506/lib/python3.6/site-packages/flask/cli.py", line 423, in run_command
    app = DispatchingApp(info.load_app, use_eager_loading=eager_loading)
  File "/Users/nsatterl/.virtualenvs/alerta506/lib/python3.6/site-packages/flask/cli.py", line 152, in __init__
    self._load_unlocked()
  File "/Users/nsatterl/.virtualenvs/alerta506/lib/python3.6/site-packages/flask/cli.py", line 176, in _load_unlocked
    self._app = rv = self.loader()
  File "/Users/nsatterl/.virtualenvs/alerta506/lib/python3.6/site-packages/flask/cli.py", line 229, in load_app
    rv = self.create_app(self)
  File "/Users/nsatterl/.virtualenvs/alerta506/lib/python3.6/site-packages/alerta/app.py", line 32, in create_app
    app.config.update(config_override or {})
TypeError: 'ScriptInfo' object is not iterable
```