### PR TITLE
Support regex in ALLOWED_ENVIRONMENTS config setting.

### DIFF
--- a/alerta/plugins/reject.py
+++ b/alerta/plugins/reject.py
@@ -12,6 +12,7 @@ from alerta.plugins import PluginBase
 LOG = logging.getLogger('alerta.plugins.reject')
 
 ORIGIN_BLACKLIST_REGEX = [re.compile(x) for x in app.config['ORIGIN_BLACKLIST']]
+ALLOWED_ENVIRONMENT_REGEX = [re.compile(x) for x in app.config['ALLOWED_ENVIRONMENTS']]
 ALLOWED_ENVIRONMENTS = app.config.get('ALLOWED_ENVIRONMENTS', [])
 
 
@@ -22,9 +23,9 @@ class RejectPolicy(PluginBase):
             LOG.warning("[POLICY] Alert origin '%s' has been blacklisted", alert.origin)
             raise RejectException("[POLICY] Alert origin '%s' has been blacklisted" % alert.origin)
 
-        if alert.environment not in ALLOWED_ENVIRONMENTS:
-            LOG.warning("[POLICY] Alert environment must be one of %s", ', '.join(ALLOWED_ENVIRONMENTS))
-            raise RejectException("[POLICY] Alert environment must be one of %s" % ', '.join(ALLOWED_ENVIRONMENTS))
+        if not any(regex.match(alert.environment) for regex in ALLOWED_ENVIRONMENT_REGEX):
+            LOG.warning("[POLICY] Alert environment does not match one of %s", ', '.join(ALLOWED_ENVIRONMENTS))
+            raise RejectException("[POLICY] Alert environment does not match one of %s" % ', '.join(ALLOWED_ENVIRONMENTS))
 
         if not alert.service:
             LOG.warning("[POLICY] Alert must define a service")


### PR DESCRIPTION
This allows alerta to deal wtih environments in a more flexible manner, without needing to make
configuration changes when an environment is modifiied.

Our environments may end up being cluster specific, so by enabling regex support, we can do something like:

```
# Actual environments may be:
# - dev-cluster-eu
# - dev-cluster-us
# - prod-cluster-eu 
# - ...

ALLOWED_ENVIRONMENTS = [ "dev-cluster.*",  "prod-cluster.*" ]
```