### PR TITLE
Do not run post-receive hooks when clearing alerts with blackout status

### DIFF
--- a/alerta/models/status_code.py
+++ b/alerta/models/status_code.py
@@ -58,6 +58,8 @@ def parse_status(name):
 def status_from_severity(previous_severity, current_severity, current_status=OPEN):
     if current_severity in [severity_code.NORMAL, severity_code.CLEARED, severity_code.OK]:
         return CLOSED
+    if current_status == BLACKOUT:
+        return BLACKOUT
     if current_status in [CLOSED, EXPIRED]:
         return OPEN
     if severity.trend(previous_severity, current_severity) == severity_code.MORE_SEVERE:

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -90,8 +90,6 @@ DEFAULT_TIMEOUT = 86400
 ALERT_TIMEOUT = DEFAULT_TIMEOUT
 HEARTBEAT_TIMEOUT = DEFAULT_TIMEOUT
 
-BLACKOUT_DURATION = 3600  # default period = 1 hour
-
 # Send verification emails to new BasicAuth users
 EMAIL_VERIFICATION = False
 SMTP_HOST = 'smtp.gmail.com'
@@ -114,5 +112,7 @@ ORIGIN_BLACKLIST = []
 #ORIGIN_BLACKLIST = ['foo/bar$', '.*/qux']  # reject all foo alerts from bar, and everything from qux
 ALLOWED_ENVIRONMENTS = ['Production', 'Development']  # reject alerts without allowed environments
 
-# blackout plugin settings
+# blackout settings
+BLACKOUT_DURATION = 3600  # default period = 1 hour
 NOTIFICATION_BLACKOUT = False  # True - set alert status=blackout, False - do not process alert (default)
+BLACKOUT_ACCEPT = []  # list of severities accepted during blackout period eg. ['normal', 'ok', 'cleared']

--- a/alerta/utils/api.py
+++ b/alerta/utils/api.py
@@ -51,8 +51,10 @@ def add_remote_ip(req, alert):
 
 def process_alert(alert):
 
+    skip_plugins = False
     for plugin in plugins.routing(alert):
         if alert.status == status_code.BLACKOUT:
+            skip_plugins = True
             break
         try:
             alert = plugin.pre_receive(alert)
@@ -78,7 +80,7 @@ def process_alert(alert):
 
     updated = None
     for plugin in plugins.routing(alert):
-        if alert.status == status_code.BLACKOUT:
+        if skip_plugins:
             break
         try:
             updated = plugin.post_receive(alert)

--- a/tests/test_blackouts.py
+++ b/tests/test_blackouts.py
@@ -152,18 +152,18 @@ class BlackoutsTestCase(unittest.TestCase):
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(data['alert']['status'], 'blackout')
 
-        # normal severity alert should be status=blackout
+        # normal severity alert should be status=closed
         self.alert['severity'] = 'ok'
         response = self.client.post('/alert', data=json.dumps(self.alert), headers=self.headers)
         self.assertEqual(response.status_code, 201)
         data = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(data['alert']['status'], 'blackout')
+        self.assertEqual(data['alert']['status'], 'closed')
 
-        # normal severity alert should be status=blackout (again)
+        # normal severity alert should be status=closed (again)
         response = self.client.post('/alert', data=json.dumps(self.alert), headers=self.headers)
         self.assertEqual(response.status_code, 201)
         data = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(data['alert']['status'], 'blackout')
+        self.assertEqual(data['alert']['status'], 'closed')
 
         # remove blackout
         response = self.client.delete('/blackout/' + blackout_id, headers=self.headers)


### PR DESCRIPTION
Fixes issue reported following #496 where alerts that clear an alert with blackout status trigger post-receive plugins when they shouldn't.