### PR TITLE
Unshelve alarms after shelving timeout

### DIFF
--- a/alerta/models/alert.py
+++ b/alerta/models/alert.py
@@ -431,13 +431,19 @@ class Alert(object):
 
     @staticmethod
     def housekeeping(expired_threshold=2, info_threshold=12):
-        for (id, event, last_receive_id) in db.housekeeping(expired_threshold, info_threshold):
+        for (id, event, status, last_receive_id) in db.housekeeping(expired_threshold, info_threshold):
+            if status == 'open':
+                text = 'unshelved after timeout'
+            elif status == 'expired':
+                text = 'expired after timeout'
+            else:
+                text = 'alert timeout status change'
             history = History(
                 id=last_receive_id,
                 event=event,
-                status="expired",
-                text="alert timeout status change",
+                status=status,
+                text=text,
                 change_type="status",
                 update_time=datetime.utcnow()
             )
-            db.set_status(id, "expired", history=history)
+            db.set_status(id, status, timeout=current_app.config['ALERT_TIMEOUT'], history=history)


### PR DESCRIPTION
When an alert is shelved a duration must be specified and after this period the alert will automatically be unshelved (ie. opened) to prevent shelved alerts from being forgotten. See #504 