### PR TITLE
Support multiple OAuth2 clients for Github

### DIFF
--- a/alerta/auth/github.py
+++ b/alerta/auth/github.py
@@ -19,10 +19,15 @@ def github():
         access_token_url = 'https://github.com/login/oauth/access_token'
         github_api_url = 'https://api.github.com'
 
+    client_lookup = dict(zip(
+        current_app.config['OAUTH2_CLIENT_ID'].split(','),
+        current_app.config['OAUTH2_CLIENT_SECRET'].split(',')
+    ))
+    client_secret = client_lookup.get(request.json['clientId'], None)
     params = {
         'client_id': request.json['clientId'],
         'redirect_uri': request.json['redirectUri'],
-        'client_secret': current_app.config['OAUTH2_CLIENT_SECRET'],
+        'client_secret': client_secret,
         'code': request.json['code']
     }
 


### PR DESCRIPTION
Github does not allow multiple callback URLs for a single OAuth2 application so it is necessary to create one each for web and CLI and then add them (in order) to the server config file as a comma-separated list.

**Example**
```
# Github (web,cli)
OAUTH2_CLIENT_ID = '1a725e0c58e45example,e17d26b970fd0example'
OAUTH2_CLIENT_SECRET = '2daddc40ebe236d337d80bf07fbb40e37example,dd00393551927c7e0c04d7d3acb993d76example'
```

This is only necessary if users want to use the `alerta` CLI and authenticate using Github credentials. See alerta/python-alerta-client#128