### PR TITLE
Add endpoint for TopN standing alerts

### DIFF
--- a/alerta/models/alert.py
+++ b/alerta/models/alert.py
@@ -416,6 +416,11 @@ class Alert(object):
     def get_top10_flapping(query=None):
         return db.get_topn_flapping(query)
 
+    # top 10 standing
+    @staticmethod
+    def get_top10_standing(query=None):
+        return db.get_topn_standing(query)
+
     # get environments
     @staticmethod
     def get_environments(query=None):

--- a/alerta/views/alerts.py
+++ b/alerta/views/alerts.py
@@ -329,6 +329,31 @@ def get_top10_flapping():
         )
 
 
+# top 10 standing
+@api.route('/alerts/top10/standing', methods=['OPTIONS', 'GET'])
+@cross_origin()
+@permission('read:alerts')
+@timer(count_timer)
+@jsonp
+def get_top10_standing():
+    query = qb.from_params(request.args)
+    top10 = Alert.get_top10_standing(query)
+
+    if top10:
+        return jsonify(
+            status="ok",
+            top10=top10,
+            total=len(top10)
+        )
+    else:
+        return jsonify(
+            status="ok",
+            message="not found",
+            top10=[],
+            total=0
+        )
+
+
 # get alert environments
 @api.route('/environments', methods=['OPTIONS', 'GET'])
 @cross_origin()


### PR DESCRIPTION
The "standing" of an alert is calculated by how long an alert has been present in the alert database. Usually alerts will be cleared and deleted within hours so alerts that hang around clutter up the console and are considered a nuisance. They can be identified using this API endpoint and either deleted or suppressed in future.

```
http :8080/alerts/top10/standing
HTTP/1.0 200 OK
Access-Control-Allow-Origin: http://localhost:8000
Content-Encoding: gzip
Content-Length: 378
Content-Type: application/json
Date: Mon, 16 Apr 2018 13:36:06 GMT
Server: Werkzeug/0.12.2 Python/3.6.2
Vary: Origin, Accept-Encoding

{
    "status": "ok",
    "top10": [
        {
            "count": 1,
            "duplicateCount": 1,
            "environments": [
                "Development"
            ],
            "event": "e1",
            "resources": [
                {
                    "id": "02a4686e-112c-42f0-a167-5098b43c5d4e",
                    "resource": "r1"
                }
            ],
            "services": [
                "Foo"
            ]
        },
        {
            "count": 4,
            "duplicateCount": 15,
            "environments": [
                "Production"
            ],
            "event": "HeartbeatFail",
            "resources": [
                {
                    "id": "45b91bf0-e167-47ae-aa24-76882b965b6b",
                    "resource": "quux"
                },
                {
                    "id": "9f6cbe05-201e-40c5-9c95-36fedf194e42",
                    "resource": "bar"
                },
                {
                    "id": "eadeb891-90c1-40e5-b780-b132c28497f4",
                    "resource": "quux"
                },
                {
                    "id": "1c8dc786-a5bd-4e48-8ced-d2b8a1845eed",
                    "resource": "foo"
                }
            ],
            "services": [
                "Alerta"
            ]
        }
    ],
    "total": 2
}
```