### PR TITLE
Add action endpoint for operation actions

### DIFF
--- a/alerta/database/backends/mongodb/base.py
+++ b/alerta/database/backends/mongodb/base.py
@@ -347,6 +347,28 @@ class Backend(Database):
             return_document=ReturnDocument.AFTER
         )
 
+    def set_severity_and_status(self, id, severity, status, timeout, history=None):
+        """
+        Set severity and status and update history.
+        """
+        query = {'_id': {'$regex': '^' + id}}
+
+        update = {
+            '$set': {"severity": severity, "status": status, "timeout": timeout},
+            '$push': {
+                "history": {
+                    '$each': [history.serialize],
+                    '$slice': -abs(current_app.config['HISTORY_LIMIT'])
+                }
+            }
+        }
+        return g.db.alerts.find_one_and_update(
+            query,
+            update=update,
+            projection={"history": 0},
+            return_document=ReturnDocument.AFTER
+        )
+
     def tag_alert(self, id, tags):
         """
         Append tags to tag list. Don't add same tag more than once.

--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -268,6 +268,15 @@ class Backend(Database):
         """.format(limit=current_app.config['HISTORY_LIMIT'])
         return self._update(update, {'id': id, 'like_id': id + '%', 'status': status, 'timeout': timeout, 'change': history}, returning=True)
 
+    def set_severity_and_status(self, id, severity, status, timeout, history=None):
+        update = """
+            UPDATE alerts
+            SET severity=%(severity)s, status=%(status)s, timeout=%(timeout)s, history=(history || %(change)s)[1:{limit}]
+            WHERE id=%(id)s OR id LIKE %(like_id)s
+            RETURNING *
+        """.format(limit=current_app.config['HISTORY_LIMIT'])
+        return self._update(update, {'id': id, 'like_id': id + '%', 'severity': severity, 'status': status, 'timeout': timeout, 'change': history}, returning=True)
+
     def tag_alert(self, id, tags):
         update = """
             UPDATE alerts

--- a/alerta/database/base.py
+++ b/alerta/database/base.py
@@ -117,6 +117,9 @@ class Database(Base):
     def set_status(self, id, status, timeout, history=None):
         raise NotImplementedError
 
+    def set_severity_and_status(self, id, severity, status, timeout, history=None):
+        raise NotImplementedError
+
     def tag_alert(self, id, tags):
         raise NotImplementedError
 

--- a/alerta/models/actions.py
+++ b/alerta/models/actions.py
@@ -1,0 +1,9 @@
+
+ACTION_ACK = 'ack'
+ACTION_UNACK = 'unack'
+
+ACTION_SHELVE = 'shelve'
+ACTION_UNSHELVE = 'unshelve'
+
+ACTION_OPEN = 'open'
+ACTION_CLOSE = 'close'

--- a/alerta/utils/api.py
+++ b/alerta/utils/api.py
@@ -137,10 +137,15 @@ def process_status(alert, status, text):
                 alert = updated
 
     if updated:
+        alert.status = status
         alert.tag(alert.tags)
         alert.update_attributes(alert.attributes)
 
     return alert, status, text
+
+
+def process_action(alert, action, text='', timeout=None):
+    return alert.from_action(action, text, timeout)
 
 
 def deepmerge(first, second):

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -295,6 +295,7 @@ class AlertTestCase(unittest.TestCase):
         response = self.client.post('/alert', data=json.dumps(self.normal_alert), headers=self.headers)
         self.assertEqual(response.status_code, 201)
         data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['alert']['severity'], 'normal')
         self.assertEqual(data['alert']['status'], 'closed')
 
         # severity == warning -> status=open
@@ -302,14 +303,16 @@ class AlertTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 201)
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(data['alert']['status'], 'open')
+        self.assertEqual(data['alert']['severity'], 'warning')
         self.assertEqual(data['alert']['duplicateCount'], 0)
 
         # operator=closed -> status=closed
-        response = self.client.put('/alert/' + alert_id + '/status', data=json.dumps({'status': 'closed', 'text': 'operator action'}), headers=self.headers)
+        response = self.client.put('/alert/' + alert_id + '/action', data=json.dumps({'action': 'close', 'text': 'operator action'}), headers=self.headers)
         self.assertEqual(response.status_code, 200)
         response = self.client.get('/alert/' + alert_id)
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['alert']['severity'], 'normal')
         self.assertEqual(data['alert']['status'], 'closed')
 
         # severity == warning -> status=open
@@ -317,7 +320,7 @@ class AlertTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 201)
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(data['alert']['status'], 'open')
-        self.assertEqual(data['alert']['severity'], self.app.config['DEFAULT_NORMAL_SEVERITY'])
+        self.assertEqual(data['alert']['severity'], 'warning')
         self.assertEqual(data['alert']['duplicateCount'], 0)
 
     def test_duplicate_status(self):


### PR DESCRIPTION
Fixes #520 where an operator manually closes an alert the alert severity does not change. It should change to "normal" at the same time as being "closed". The web UI will need to be updated to make use of the new "/alert/id/action" endpoint.