### PR TITLE
First implementation attempt for supporting LDAP authentication

### DIFF
--- a/alerta/app.py
+++ b/alerta/app.py
@@ -11,6 +11,7 @@ from alerta.utils.plugin import Plugins
 from alerta.utils.config import Config
 from alerta.utils.key import ApiKeyHelper
 from alerta.utils.webhook import CustomWebhooks
+from alerta import auth
 
 config = Config()
 severity = Severity()
@@ -44,6 +45,8 @@ def create_app(config_override=None, environment=None):
     qb.init_app(app)
     sentry.init_app(app)
 
+    auth.init_app(app)
+
     from alerta.utils.format import CustomJSONEncoder
     app.json_encoder = CustomJSONEncoder
 
@@ -53,8 +56,8 @@ def create_app(config_override=None, environment=None):
     from alerta.webhooks import webhooks
     app.register_blueprint(webhooks)
 
-    from alerta.auth import auth
-    app.register_blueprint(auth)
+    from alerta.auth import auth as auth_blueprint
+    app.register_blueprint(auth_blueprint)
 
     from alerta.management import mgmt
     app.register_blueprint(mgmt)

--- a/alerta/auth/__init__.py
+++ b/alerta/auth/__init__.py
@@ -1,12 +1,17 @@
-
 from flask import Blueprint, request
 
 from alerta.exceptions import ApiError
 
-auth = Blueprint('auth', __name__)
+auth = Blueprint('auth', __name__) 
 
-from . import basic, github, gitlab, google, keycloak, pingfederate, saml2, userinfo
-
+def init_app(app):
+    from . import github, gitlab, google, keycloak, pingfederate, saml2, userinfo
+    
+    # If LDAP_SERVER is defined in config then use basic_ldap instead of basic to provide LDAP authentication
+    if "LDAP_SERVER" in app.config:
+        from . import basic_ldap
+    else:
+        from . import basic
 
 @auth.before_request
 def only_json():

--- a/alerta/auth/basic_ldap.py
+++ b/alerta/auth/basic_ldap.py
@@ -1,0 +1,72 @@
+
+import logging
+from uuid import uuid4
+
+from flask import current_app, request, jsonify, render_template
+from flask_cors import cross_origin
+
+from alerta.auth.utils import is_authorized, create_token, get_customers
+from alerta.exceptions import ApiError
+from alerta.models.user import User
+from alerta.utils.api import absolute_url
+from . import auth
+
+import ldap
+
+@auth.route('/auth/signup', methods=['OPTIONS', 'POST'])
+@cross_origin(supports_credentials=True)
+def signup():
+    raise NotImplementedError
+
+@auth.route('/auth/login', methods=['OPTIONS', 'POST'])
+@cross_origin(supports_credentials=True)
+def login():
+    # Retrieve required fields from client request
+    try:
+        email = request.json.get('username', None) or request.json['email']
+        password = request.json['password']
+    except KeyError:
+        raise ApiError("must supply 'username' and 'password'", 401)
+
+    username = email.split("@")[0]
+    domain = email.split("@")[1]
+
+    # Validate LDAP domain
+    if not 'LDAP_DOMAINS' in current_app.config:
+        raise ApiError("LDAP_DOMAINS not configured", 500)
+
+    if domain not in current_app.config["LDAP_DOMAINS"]:
+        raise ApiError("unauthorized domain", 403)
+
+    userdn = current_app.config["LDAP_DOMAINS"][domain] % username
+
+    # Attempt LDAP AUTH
+    try:
+        ldap_connection = ldap.initialize(current_app.config['LDAP_SERVER'])
+        ldap_connection.simple_bind_s(userdn, password)
+
+    except ldap.INVALID_CREDENTIALS:
+        raise ApiError("invalid username or password", 401)
+
+    except:
+        raise ApiError("logon failed", 500)
+
+    # Create user if not yet there
+    user = User.find_by_email(email=email)
+    if not user:
+        user = User(username, email, "", ["user"], "LDAP user")
+        user.create()
+        user.set_email_verified()
+
+    # Check user is active
+    if user.status != 'active':
+        raise ApiError('user not active', 403)
+
+    # Assign customers & update last login time
+    customers = get_customers(user.email, groups=[user.domain])
+    user.update_last_login()
+
+    # Generate token
+    token = create_token(user.id, user.name, user.email, provider='basic', customers=customers,
+                         roles=user.roles, email=user.email, email_verified=user.email_verified)
+    return jsonify(token=token.tokenize)


### PR DESCRIPTION
Hi!
This is a first attempt on implementing support for LDAP authentication as an alternative to the built-in base authentication. 
Note that the built-in user authorization (via user.py) is still used.

This implementation will not change anything for those already using the basic authentication, however if the configuration value "LDAP_SERVER" is specified it will use basic_ldap.py in favor of basic.py. 

It supports multiple LDAP domains/basedn's, chosen from the users domain. 

Sample config for OpenLDAP (Active Directory should also be supported, but untested.):
```
LDAP_SERVER = 'ldaps://ldap.example.com'
LDAP_DOMAINS = {
    'example.com': 'cn=%s,dc=example,dc=com'
}
```

An earlier issue on this exists (#194 ) and was closed as satellizer did not support LDAP, however this pull request does not require any frontend change to support LDAP. 

Suggestions for improvement is highly appreciated as this is my first contribution (so far) towards this project. 