### PR TITLE
Fix user permissions during sign-up and update

### DIFF
--- a/alerta/auth/basic.py
+++ b/alerta/auth/basic.py
@@ -1,14 +1,12 @@
 
-import logging
 from uuid import uuid4
 
 from flask import current_app, request, jsonify, render_template
 from flask_cors import cross_origin
 
-from alerta.auth.utils import is_authorized, create_token, get_customers
+from alerta.auth.utils import is_authorized, create_token, get_customers, send_confirmation
 from alerta.exceptions import ApiError
 from alerta.models.user import User
-from alerta.utils.api import absolute_url
 from . import auth
 
 
@@ -19,6 +17,10 @@ def signup():
         user = User.parse(request.json)
     except Exception as e:
         raise ApiError(str(e), 400)
+
+    # set sign-up defaults
+    user.roles = ['user']
+    user.email_verified = False
 
     # check allowed domain
     if is_authorized('ALLOWED_EMAIL_DOMAINS', groups=[user.domain]):
@@ -104,69 +106,3 @@ def verify_email(hash):
         return render_template('auth/verify_success.html', email=user.email)
     else:
         return render_template('auth/verify_failed.html')
-
-
-try:
-    import smtplib
-    import socket
-    from email.mime.text import MIMEText
-    from email.mime.multipart import MIMEMultipart
-except ImportError:
-    pass
-
-
-def send_confirmation(user, hash):
-
-    smtp_host = current_app.config['SMTP_HOST']
-    smtp_port = current_app.config['SMTP_PORT']
-    mail_localhost = current_app.config['MAIL_LOCALHOST']
-    ssl_key_file = current_app.config['SSL_KEY_FILE']
-    ssl_cert_file = current_app.config['SSL_CERT_FILE']
-
-    mail_from = current_app.config['MAIL_FROM']
-    smtp_username = current_app.config.get('SMTP_USERNAME', mail_from)
-    smtp_password = current_app.config['SMTP_PASSWORD']
-
-    msg = MIMEMultipart('related')
-    msg['Subject'] = "[Alerta] Please verify your email '%s'" % user.email
-    msg['From'] = mail_from
-    msg['To'] = user.email
-    msg.preamble = "[Alerta] Please verify your email '%s'" % user.email
-
-    text = 'Hello {name}!\n\n' \
-           'Please verify your email address is {email} by clicking on the link below:\n\n' \
-           '{url}\n\n' \
-           'You\'re receiving this email because you recently created a new Alerta account.' \
-           ' If this wasn\'t you, please ignore this email.'.format(
-               name=user.name, email=user.email, url=absolute_url('/auth/confirm/' + hash)
-           )
-
-    msg_text = MIMEText(text, 'plain', 'utf-8')
-    msg.attach(msg_text)
-
-    try:
-        if current_app.config['SMTP_USE_SSL']:
-            mx = smtplib.SMTP_SSL(smtp_host, smtp_port, local_hostname=mail_localhost, keyfile=ssl_key_file, certfile=ssl_cert_file)
-        else:
-            mx = smtplib.SMTP(smtp_host, smtp_port, local_hostname=mail_localhost)
-
-        if current_app.config['DEBUG']:
-            mx.set_debuglevel(True)
-
-        mx.ehlo()
-
-        if current_app.config['SMTP_STARTTLS']:
-            mx.starttls()
-
-        if smtp_password:
-            mx.login(smtp_username, smtp_password)
-
-        mx.sendmail(mail_from, [user.email], msg.as_string())
-        mx.close()
-    except smtplib.SMTPException as e:
-        logging.error('Failed to send email : %s', str(e))
-    except (socket.error, socket.herror, socket.gaierror) as e:
-        logging.error('Mail server connection error: %s', str(e))
-        return
-    except Exception as e:
-        logging.error('Unhandled exception: %s', str(e))

--- a/alerta/auth/utils.py
+++ b/alerta/auth/utils.py
@@ -1,5 +1,7 @@
 
 import re
+import logging
+
 from datetime import datetime, timedelta
 from functools import wraps
 from uuid import uuid4
@@ -13,7 +15,7 @@ from alerta.models.customer import Customer
 from alerta.models.key import ApiKey
 from alerta.models.permission import Permission
 from alerta.models.token import Jwt
-
+from alerta.utils.api import absolute_url
 
 try:
     import bcrypt
@@ -128,3 +130,69 @@ def permission(scope):
 
         return wrapped
     return decorated
+
+
+try:
+    import smtplib
+    import socket
+    from email.mime.text import MIMEText
+    from email.mime.multipart import MIMEMultipart
+except ImportError:
+    pass
+
+
+def send_confirmation(user, hash):
+
+    smtp_host = current_app.config['SMTP_HOST']
+    smtp_port = current_app.config['SMTP_PORT']
+    mail_localhost = current_app.config['MAIL_LOCALHOST']
+    ssl_key_file = current_app.config['SSL_KEY_FILE']
+    ssl_cert_file = current_app.config['SSL_CERT_FILE']
+
+    mail_from = current_app.config['MAIL_FROM']
+    smtp_username = current_app.config.get('SMTP_USERNAME', mail_from)
+    smtp_password = current_app.config['SMTP_PASSWORD']
+
+    msg = MIMEMultipart('related')
+    msg['Subject'] = "[Alerta] Please verify your email '%s'" % user.email
+    msg['From'] = mail_from
+    msg['To'] = user.email
+    msg.preamble = "[Alerta] Please verify your email '%s'" % user.email
+
+    text = 'Hello {name}!\n\n' \
+           'Please verify your email address is {email} by clicking on the link below:\n\n' \
+           '{url}\n\n' \
+           'You\'re receiving this email because you recently created a new Alerta account.' \
+           ' If this wasn\'t you, please ignore this email.'.format(
+               name=user.name, email=user.email, url=absolute_url('/auth/confirm/' + hash)
+           )
+
+    msg_text = MIMEText(text, 'plain', 'utf-8')
+    msg.attach(msg_text)
+
+    try:
+        if current_app.config['SMTP_USE_SSL']:
+            mx = smtplib.SMTP_SSL(smtp_host, smtp_port, local_hostname=mail_localhost, keyfile=ssl_key_file, certfile=ssl_cert_file)
+        else:
+            mx = smtplib.SMTP(smtp_host, smtp_port, local_hostname=mail_localhost)
+
+        if current_app.config['DEBUG']:
+            mx.set_debuglevel(True)
+
+        mx.ehlo()
+
+        if current_app.config['SMTP_STARTTLS']:
+            mx.starttls()
+
+        if smtp_password:
+            mx.login(smtp_username, smtp_password)
+
+        mx.sendmail(mail_from, [user.email], msg.as_string())
+        mx.close()
+    except smtplib.SMTPException as e:
+        logging.error('Failed to send email : %s', str(e))
+    except (socket.error, socket.herror, socket.gaierror) as e:
+        logging.error('Mail server connection error: %s', str(e))
+        return
+    except Exception as e:
+        logging.error('Unhandled exception: %s', str(e))

--- a/alerta/models/user.py
+++ b/alerta/models/user.py
@@ -154,6 +154,8 @@ class User(object):
         if kwargs.get('name', None) is not None:
             update['name'] = kwargs['name']
         if kwargs.get('email', None) is not None:
+            if '@' not in kwargs.get('email'):
+                raise ValueError('Value for "email" not valid: %s' % kwargs['email'])
             update['email'] = kwargs['email']
             update['email_verified'] = False
         if kwargs.get('password', None) is not None:

--- a/alerta/views/users.py
+++ b/alerta/views/users.py
@@ -1,8 +1,11 @@
 
-from flask import jsonify, request, current_app
+from uuid import uuid4
+
+from flask import jsonify, request, g, current_app
 from flask_cors import cross_origin
 
 from alerta.app import qb
+from alerta.auth.utils import is_authorized, create_token, get_customers, send_confirmation
 from alerta.auth.utils import permission
 from alerta.exceptions import ApiError
 from alerta.models.user import User
@@ -10,7 +13,47 @@ from alerta.utils.api import jsonp
 from . import api
 
 
-# NOTE: "user create" method is basic auth "sign up" method
+@api.route('/user', methods=['OPTIONS', 'POST'])
+@cross_origin()
+@permission('admin:users')
+@jsonp
+def create_user():
+    try:
+        user = User.parse(request.json)
+    except Exception as e:
+        raise ApiError(str(e), 400)
+
+    # check allowed domain
+    if is_authorized('ALLOWED_EMAIL_DOMAINS', groups=[user.domain]):
+        raise ApiError("unauthorized domain", 403)
+
+    if User.find_by_email(email=user.email):
+        raise ApiError("username already exists", 409)
+
+    try:
+        user = user.create()
+    except Exception as e:
+        ApiError(str(e), 500)
+
+    # if email verification is enforced, deny login and send email
+    if current_app.config['EMAIL_VERIFICATION'] and not user.email_verified:
+        hash = str(uuid4())
+        send_confirmation(user, hash)
+        user.set_email_hash(hash)
+        raise ApiError('email not verified', 401)
+
+    # check user is active
+    if user.status != 'active':
+        raise ApiError('user not active', 403)
+
+    # assign customers & update last login time
+    customers = get_customers(user.email, groups=[user.domain])
+    user.update_last_login()
+
+    # generate token
+    token = create_token(user.id, user.name, user.email, provider='basic', customers=customers,
+                         roles=user.roles, email=user.email, email_verified=user.email_verified)
+    return jsonify(token=token.tokenize)
 
 
 @api.route('/user/<user_id>', methods=['OPTIONS', 'PUT'])
@@ -35,15 +78,61 @@ def update_user(user_id):
         raise ApiError("failed to update user", 500)
 
 
-@api.route('/user/<user_id>/attributes', methods=['OPTIONS', 'PUT'])
+@api.route('/user/me', methods=['OPTIONS', 'PUT'])
 @cross_origin()
 @permission('write:users')
+@jsonp
+def update_me():
+    if not request.json:
+        raise ApiError("nothing to change", 400)
+
+    if 'roles' in request.json:
+        raise ApiError('not allowed to update roles', 400)
+    if 'email_verified' in request.json:
+        raise ApiError('not allowed to set email verified', 400)
+
+    user = User.find_by_email(g.user)
+
+    if not user:
+        raise ApiError("not found", 404)
+
+    if 'email' in request.json and User.find_by_email(request.json['email']):
+        raise ApiError("user with email already exists", 409)
+
+    if user.update(**request.json):
+        return jsonify(status="ok")
+    else:
+        raise ApiError("failed to update user", 500)
+
+
+@api.route('/user/<user_id>/attributes', methods=['OPTIONS', 'PUT'])
+@cross_origin()
+@permission('admin:users')
 @jsonp
 def update_user_attributes(user_id):
     if not request.json.get('attributes', None):
         raise ApiError("must supply 'attributes' as json data", 400)
 
     user = User.find_by_id(user_id)
+
+    if not user:
+        raise ApiError("not found", 404)
+
+    if user.update_attributes(request.json['attributes']):
+        return jsonify(status="ok")
+    else:
+        raise ApiError("failed to update attributes", 500)
+
+
+@api.route('/user/me/attributes', methods=['OPTIONS', 'PUT'])
+@cross_origin()
+@permission('write:users')
+@jsonp
+def update_me_attributes():
+    if not request.json.get('attributes', None):
+        raise ApiError("must supply 'attributes' as json data", 400)
+
+    user = User.find_by_email(g.user)
 
     if not user:
         raise ApiError("not found", 404)
@@ -81,7 +170,7 @@ def search_users():
 
 @api.route('/user/<user_id>', methods=['OPTIONS', 'DELETE'])
 @cross_origin()
-@permission('write:users')
+@permission('admin:users')
 @jsonp
 def delete_user(user_id):
     user = User.find_by_id(user_id)


### PR DESCRIPTION
 * prevent users from setting their own roles and self-verifying email during sign-up
 * change all "/user/<user_id>" endpoints to `admin:users` permissions to prevent users non-admin 
 users from updating or deleting other users among other things
 * new "/user/me" and "/user/me/attributes" endpoints to allow users to update their own details

Fixes #525 