### PR TITLE
Make requirements.txt just a reference to setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,1 @@
-Flask>=0.10.1
-Flask-Cors>=3.0.2
-Flask-Compress>=1.4.0
-raven[flask]>=6.2.1
-pymongo>=3.0
-psycopg2
-requests
-python-dateutil
-pytz
-PyJWT
-bcrypt
+.


### PR DESCRIPTION
Fixes #534 and Closes #536 

See https://stackoverflow.com/questions/14399534/reference-requirements-txt-for-the-install-requires-kwarg-in-setuptools-setup-py