### PR TITLE
Allow users with a customer domain mapping to '*' to view all customers

### DIFF
--- a/alerta/database/backends/mongodb/base.py
+++ b/alerta/database/backends/mongodb/base.py
@@ -1027,8 +1027,13 @@ class Backend(Database):
             response = g.db.customers.find_one({"match": match}, projection={"customer": 1, "_id": 0})
             if response:
                 customers.append(response['customer'])
+
         if customers:
+            if '*' in customers:
+                return '*' # all customers
+
             return customers
+
         raise NoCustomerMatch("No customer lookup configured for user '%s' or '%s'" % (login, ','.join(matches)))
 
     #### METRICS

--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -812,8 +812,13 @@ class Backend(Database):
             response = self._fetchone(select, (match,))
             if response:
                 customers.append(response.customer)
+
         if customers:
+            if '*' in customers:
+                return '*'  # all customers
+
             return customers
+
         raise NoCustomerMatch("No customer lookup configured for user '%s' or '%s'" % (login, ','.join(matches)))
 
     #### METRICS


### PR DESCRIPTION
Hi @satterly !

This pull request allows users with a wildcard domain mapping to view all customers (as those specified in "ADMIN_USERS" in the configuration may). 

When specifying a single "*" in the customer field, all users part of that domain will be able to view alarms for all customers. 