### PR TITLE
Get plain body if json and text is missing

### DIFF
--- a/alerta/webhooks/custom.py
+++ b/alerta/webhooks/custom.py
@@ -16,7 +16,7 @@ def custom(webhook):
     try:
         incomingAlert = custom_webhooks.webhooks[webhook].incoming(
             query_string=request.args,
-            payload=request.get_json() or request.get_data(as_text=True)
+            payload=request.get_json() or request.get_data(as_text=True) or request.values
         )
     except ValueError as e:
         raise ApiError(str(e), 400)


### PR DESCRIPTION
This PR makes it possible to use inbound webhooks with type application/x-www-form-urlencoded.