### PR TITLE
Add setting for non-fatal index creation handling

### DIFF
--- a/alerta/database/backends/mongodb/base.py
+++ b/alerta/database/backends/mongodb/base.py
@@ -28,6 +28,17 @@ class Backend(Database):
             db = self.client.get_default_database()
 
         # create unique indexes
+        try:
+            self._create_indexes(db)
+        except Exception as e:
+            if current_app.config['MONGO_RAISE_ON_ERROR']:
+                raise
+            current_app.logger.warning(e)
+
+        return db
+
+    @staticmethod
+    def _create_indexes(db):
         db.alerts.create_index(
             [('environment', ASCENDING), ('customer', ASCENDING), ('resource', ASCENDING), ('event', ASCENDING)],
             unique=True
@@ -39,8 +50,6 @@ class Backend(Database):
         db.perms.create_index([('match', ASCENDING)], unique=True)
         db.users.create_index([('email', ASCENDING)], unique=True)
         db.metrics.create_index([('group', ASCENDING), ('name', ASCENDING)], unique=True)
-
-        return db
 
     @property
     def name(self):

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -25,6 +25,7 @@ HISTORY_LIMIT = 100  # cap the number of alert history entries
 # MongoDB
 MONGO_URI = 'mongodb://localhost:27017/monitoring'
 MONGO_DATABASE = None  # can be used to override default database, above
+MONGO_RAISE_ON_ERROR = True
 
 # PostgreSQL
 POSTGRES_URI = 'postgres://localhost:5432/monitoring'  # not used (use DATABASE_URL)


### PR DESCRIPTION
Set `MONGO_RAISE_ON_ERROR=False` if creating MongoDB indexes manually and Alerta API should not fail to start if automatic index creation fails.

Fixes #569 