### PR TITLE
Allow Content-type other than application/json for POST requests to /…

### DIFF
--- a/alerta/auth/__init__.py
+++ b/alerta/auth/__init__.py
@@ -15,5 +15,8 @@ from . import github, gitlab, google, keycloak, pingfederate, saml2, userinfo
 
 @auth.before_request
 def only_json():
-    if request.method in ['POST', 'PUT'] and not request.is_json and not request.path == '/auth/saml':
-        raise ApiError("POST and PUT requests must set 'Content-type' to 'application/json'", 415)
+    # SAML2 Assertion Consumer Service expects POST request with 'Content-Type': 'application/x-www-form-urlencoded' from IdP
+    if request.method == 'POST' and request.path == '/auth/saml' and request.headers['Content-Type'] == 'application/x-www-form-urlencoded':
+        return
+    if request.method in ['POST', 'PUT'] and not request.is_json:
+        raise ApiError("POST and PUT requests must set 'Content-Type' to 'application/json'", 415)

--- a/alerta/auth/__init__.py
+++ b/alerta/auth/__init__.py
@@ -15,5 +15,5 @@ from . import github, gitlab, google, keycloak, pingfederate, saml2, userinfo
 
 @auth.before_request
 def only_json():
-    if request.method in ['POST', 'PUT'] and not request.is_json:
+    if request.method in ['POST', 'PUT'] and not request.is_json and not request.path == '/auth/saml':
         raise ApiError("POST and PUT requests must set 'Content-type' to 'application/json'", 415)


### PR DESCRIPTION
…auth/saml endpoint

* Allow the IdP to send the SAMLResponse and RelayState to the Assertion Consumer Service (Alerta) via POST request with Content-Type: application/x-www-form-urlencoded