### PR TITLE
Fix History limit for postgres backend

### DIFF
--- a/alerta/models/alert.py
+++ b/alerta/models/alert.py
@@ -124,7 +124,7 @@ class Alert(object):
             'receiveTime': self.receive_time,
             'lastReceiveId': self.last_receive_id,
             'lastReceiveTime': self.last_receive_time,
-            'history': [h.serialize for h in self.history]
+            'history': [h.serialize for h in sorted(self.history, key=lambda x: x.update_time)]
         }
 
     def get_id(self, short=False):


### PR DESCRIPTION
The alert history array is being limited to the `HISTORY_LIMIT` (which defaults to "100"). Whenever a new history update is added to the array the array is "sliced" to limit the number of elements so it doesn't grow forever. However, the slice range was wrong so it was always dropping off the newest element of the array instead of the oldest.

Postgres doesn't support a negative slice (ie. take the last n elements of an array) so the alternative is to prepend new elements and then slice the array. Reversing the order in which new elements are added will make existing alert histories expire incorrectly but new alert histories should work correctly (and once old alert histories are completely replaced they will behave correctly as well).

Fixes #592 