### PR TITLE
Fix Grafana webhook to replace dots in tag keys

### DIFF
--- a/alerta/webhooks/grafana.py
+++ b/alerta/webhooks/grafana.py
@@ -1,3 +1,4 @@
+import json
 
 from flask import request, g, jsonify
 from flask_cors import cross_origin
@@ -31,6 +32,8 @@ def parse_grafana(alert, match, args):
     service = args.get('service', 'Grafana')
 
     attributes = match.get('tags', None) or dict()
+    attributes = {k.replace('.', '_'):v for (k, v) in attributes.items()}
+
     attributes['ruleId'] = str(alert['ruleId'])
     if 'ruleUrl' in alert:
         attributes['ruleUrl'] = '<a href="%s" target="_blank">Rule</a>' % alert['ruleUrl']
@@ -51,7 +54,7 @@ def parse_grafana(alert, match, args):
         origin=origin,
         event_type=event_type,
         timeout=300,
-        raw_data=alert
+        raw_data=json.dumps(alert)
     )
 
 

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -342,7 +342,8 @@ class WebhooksTestCase(unittest.TestCase):
                         "dimension": "user",
                         "family": "utilization",
                         "instance": "zeta.domain",
-                        "job": "monitoring"
+                        "job": "monitoring",
+                        "info.host_id": "i-0d0721c7f97545d43"
                     }
                 }
             ],
@@ -646,7 +647,6 @@ class WebhooksTestCase(unittest.TestCase):
         self.assertEqual(data['alert']['service'], ['Webserver Health'])
         self.assertEqual(data['alert']['text'], 'CPU (agent) for webserver-85 is above the threshold of 1% with a value of 28.5%')
 
-
     def test_grafana_webhook(self):
 
         # state=alerting
@@ -654,6 +654,9 @@ class WebhooksTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 201)
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(data['status'], "ok")
+
+        # check tags with dots are replaced with underscores ie. 'info.host_id' => 'info_host_id'
+        self.assertEqual(data['alert']['attributes']['info_host_id'], 'i-0d0721c7f97545d43')
 
         alert_id = data['id']
 


### PR DESCRIPTION
Grafana alerts generated from Elasticsearch data can contain "dots" in the tag keys which is rejected by Alerta API because "." and "$" are not supported by MongoDB. The fix is to replace any dot with an underscore.

/cc @davidglvn 