### PR TITLE
Use 'request.form' method instead of 'request.values' to simplify data

### DIFF
--- a/alerta/webhooks/custom.py
+++ b/alerta/webhooks/custom.py
@@ -16,7 +16,7 @@ def custom(webhook):
     try:
         incomingAlert = custom_webhooks.webhooks[webhook].incoming(
             query_string=request.args,
-            payload=request.get_json() or request.get_data(as_text=True) or request.values
+            payload=request.get_json() or request.get_data(as_text=True) or request.form
         )
     except ValueError as e:
         raise ApiError(str(e), 400)


### PR DESCRIPTION
Returning a combined multidict from custom webhooks for form data was confusing users because it wasn't obvious how to retrieve multipart form data from the webhook response.

Changing from `request.values` to `request.form` makes accessing returned form urlencoded data a simple as accessing a python dictionary.

The alternative is to require users to use `payload.to_dict()` in the webhook which was not obvious.

Note: This changes the logic added by @tester22 in #571 so could have consequences for custom webhooks that already rely of the return format of `request.values`.

/cc @manavrawat10
