### PR TITLE
added possibility to set timeout from grafana webhook

### DIFF
--- a/alerta/webhooks/grafana.py
+++ b/alerta/webhooks/grafana.py
@@ -30,6 +30,8 @@ def parse_grafana(alert, match, args):
     group = args.get('group', 'Performance')
     origin = args.get('origin', 'Grafana')
     service = args.get('service', 'Grafana')
+    timeout = args.get('timeout', 86400)
+
 
     attributes = match.get('tags', None) or dict()
     attributes = {k.replace('.', '_'):v for (k, v) in attributes.items()}
@@ -53,7 +55,7 @@ def parse_grafana(alert, match, args):
         attributes=attributes,
         origin=origin,
         event_type=event_type,
-        timeout=300,
+        timeout=timeout,
         raw_data=json.dumps(alert)
     )
 

--- a/alerta/webhooks/grafana.py
+++ b/alerta/webhooks/grafana.py
@@ -1,6 +1,6 @@
 import json
 
-from flask import request, g, jsonify
+from flask import request, jsonify, current_app
 from flask_cors import cross_origin
 
 from alerta.app import qb
@@ -30,7 +30,7 @@ def parse_grafana(alert, match, args):
     group = args.get('group', 'Performance')
     origin = args.get('origin', 'Grafana')
     service = args.get('service', 'Grafana')
-    timeout = args.get('timeout', 86400)
+    timeout = args.get('timeout', current_app.config['ALERT_TIMEOUT'])
 
 
     attributes = match.get('tags', None) or dict()


### PR DESCRIPTION
Is there any way of using the default alert timeout setting from the config file instead of hardcoding the fallback value to 86400?