### PR TITLE
Display better error message for unknown webhook

### DIFF
--- a/alerta/webhooks/custom.py
+++ b/alerta/webhooks/custom.py
@@ -18,6 +18,8 @@ def custom(webhook):
             query_string=request.args,
             payload=request.get_json() or request.get_data(as_text=True) or request.form
         )
+    except KeyError as e:
+        raise ApiError("Webhook '%s' not found. Did you mean to use POST instead of GET?" % webhook, 404)
     except ValueError as e:
         raise ApiError(str(e), 400)
 


### PR DESCRIPTION
```
$ http :8080/webhooks/prometheus?api-key=demo-key
HTTP/1.0 400 BAD REQUEST
Access-Control-Allow-Origin: http://localhost:8000
Content-Length: 127
Content-Type: application/json
Date: Tue, 28 Aug 2018 22:51:40 GMT
Server: Werkzeug/0.14.1 Python/3.6.5
Vary: Origin

{
    "code": 404,
    "errors": null,
    "message": "Webhook 'prometheus' not found. Did you mean to use POST instead of GET?",
    "status": "error"
}

$ http POST :8080/webhooks/prometheus?api-key=demo-key
HTTP/1.0 400 BAD REQUEST
Access-Control-Allow-Origin: http://localhost:8000
Content-Length: 101
Content-Type: application/json
Date: Tue, 28 Aug 2018 22:51:54 GMT
Server: Werkzeug/0.14.1 Python/3.6.5
Vary: Origin

{
    "code": 400,
    "errors": null,
    "message": "no alerts in Prometheus notification payload",
    "status": "error"
}
```