### PR TITLE
Do not allow customer name to be an empty string

### DIFF
--- a/alerta/models/alert.py
+++ b/alerta/models/alert.py
@@ -71,6 +71,8 @@ class Alert(object):
             raise ValueError('attributes must be a JSON object')
         if not isinstance(json.get('timeout') if json.get('timeout', None) is not None else 0, int):
             raise ValueError('timeout must be an integer')
+        if json.get('customer', None) == '':
+            raise ValueError('customer must not be an empty string')
 
         return Alert(
             id=json.get('id', None),

--- a/tests/test_customers.py
+++ b/tests/test_customers.py
@@ -359,3 +359,12 @@ class AuthTestCase(unittest.TestCase):
             g.customers = ['Customer1']
             g.scopes = ['admin:keys', 'read:keys', 'write:keys']
             self.assertEqual(assign_customer(wanted='Customer2', permission='admin:keys'), 'Customer2')
+
+    def test_invalid_customer(self):
+
+        self.foo_alert['customer'] = ''
+
+        response = self.client.post('/alert', data=json.dumps(self.foo_alert), headers=self.admin_headers)
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['message'], 'customer must not be an empty string')


### PR DESCRIPTION
It is possible to set customer to an empty string and cause problems because "is duplicate" and "is correlate" checks would return false but then saving to the database would return a constraint violation error.

```
$ sh tool2/tool2.sh
{"code":500,"errors":null,"message":"duplicate key value violates unique constraint \"env_res_evt_cust_key\"\nDETAIL:  Key (environment, resource, event, (COALESCE(customer, ''::text)))=(None, WIN-123456789, Tool2, ) already exists.\n","status":"error"}
```