### PR TITLE
Fix history change type issue

### DIFF
--- a/alerta/database/backends/mongodb/base.py
+++ b/alerta/database/backends/mongodb/base.py
@@ -442,7 +442,6 @@ class Backend(Database):
 
         history = list()
         for response in responses:
-            change_type = 'severity' if response['history'].get('severity', None) else 'status'
             history.append(
                 {
                     "id": response['history']['id'],
@@ -459,7 +458,7 @@ class Backend(Database):
                     "attributes": response['attributes'],
                     "origin": response['origin'],
                     "updateTime": response['history']['updateTime'],
-                    "type": response['history'].get('type', change_type),
+                    "type": response['history'].get('type', 'unknown'),
                     "customer": response.get('customer', None)
                 }
             )

--- a/alerta/database/backends/mongodb/base.py
+++ b/alerta/database/backends/mongodb/base.py
@@ -431,8 +431,8 @@ class Backend(Database):
         }
 
         pipeline = [
-            {'$match': query.where},
             {'$unwind': '$history'},
+            {'$match': query.where},
             {'$project': fields},
             {'$limit': current_app.config['HISTORY_LIMIT']},
             {'$sort': {'history.updateTime': 1}}
@@ -442,45 +442,27 @@ class Backend(Database):
 
         history = list()
         for response in responses:
-            if 'severity' in response['history']:
-                history.append(
-                    {
-                        "id": response['_id'],  # or response['history']['id']
-                        "resource": response['resource'],
-                        "event": response['history']['event'],
-                        "environment": response['environment'],
-                        "severity": response['history']['severity'],
-                        "service": response['service'],
-                        "group": response['group'],
-                        "value": response['history']['value'],
-                        "text": response['history']['text'],
-                        "tags": response['tags'],
-                        "attributes": response['attributes'],
-                        "origin": response['origin'],
-                        "updateTime": response['history']['updateTime'],
-                        "type": response['history'].get('type', 'unknown'),
-                        "customer": response.get('customer', None)
-                    }
-                )
-            elif 'status' in response['history']:
-                history.append(
-                    {
-                        "id": response['_id'],  # or response['history']['id']
-                        "resource": response['resource'],
-                        "event": response['event'],
-                        "environment": response['environment'],
-                        "status": response['history']['status'],
-                        "service": response['service'],
-                        "group": response['group'],
-                        "text": response['history']['text'],
-                        "tags": response['tags'],
-                        "attributes": response['attributes'],
-                        "origin": response['origin'],
-                        "updateTime": response['history']['updateTime'],
-                        "type": response['history'].get('type', 'unknown'),
-                        "customer": response.get('customer', None)
-                    }
-                )
+            change_type = 'severity' if response['history'].get('severity', None) else 'status'
+            history.append(
+                {
+                    "id": response['history']['id'],
+                    "resource": response['resource'],
+                    "event": response['history']['event'],
+                    "environment": response['environment'],
+                    "severity": response['history']['severity'],
+                    "service": response['service'],
+                    "status": response['history']['status'],
+                    "group": response['group'],
+                    "value": response['history']['value'],
+                    "text": response['history']['text'],
+                    "tags": response['tags'],
+                    "attributes": response['attributes'],
+                    "origin": response['origin'],
+                    "updateTime": response['history']['updateTime'],
+                    "type": response['history'].get('type', change_type),
+                    "customer": response.get('customer', None)
+                }
+            )
         return history
 
     #### COUNTS

--- a/alerta/models/history.py
+++ b/alerta/models/history.py
@@ -86,7 +86,7 @@ class RichHistory(object):
         self.attributes = kwargs.get('attributes', None) or dict()
         self.origin = kwargs.get('origin', None)
         self.update_time = kwargs.get('update_time', None)
-        self.event_type = kwargs.get('event_type', kwargs.get('type', None))
+        self.change_type = kwargs.get('change_type', kwargs.get('type', None))
         self.customer = kwargs.get('customer', None)
 
     @property
@@ -104,7 +104,7 @@ class RichHistory(object):
             'attributes': self.attributes,
             'origin': self.origin,
             'updateTime': self.update_time,
-            'type': self.event_type,
+            'type': self.change_type,
             'customer': self.customer
         }
 
@@ -118,8 +118,8 @@ class RichHistory(object):
         return data
 
     def __repr__(self):
-        return 'RichHistory(id=%r, environment=%r, resource=%r, event=%r, severity=%r, status=%r, customer=%r)' % (
-            self.id, self.environment, self.resource, self.event, self.severity, self.status, self.customer)
+        return 'RichHistory(id=%r, environment=%r, resource=%r, event=%r, severity=%r, status=%r, type=%r, customer=%r)' % (
+            self.id, self.environment, self.resource, self.event, self.severity, self.status, self.change_type, self.customer)
 
     @classmethod
     def from_document(cls, doc):
@@ -138,7 +138,7 @@ class RichHistory(object):
             attributes=doc.get('attributes', dict()),
             origin=doc.get('origin', None),
             update_time=doc.get('updateTime', None),
-            event_type=doc.get('type', None),
+            change_type=doc.get('type', None),
             customer=doc.get('customer', None)
         )
 
@@ -159,7 +159,7 @@ class RichHistory(object):
             attributes=dict(rec.attributes),
             origin=rec.origin,
             update_time=rec.update_time,
-            event_type=rec.type,
+            change_type=rec.type,
             customer=rec.customer
         )
 


### PR DESCRIPTION
Fix query for alert history changes and use "change_type" consistently instead of "event_type" (see also related alerta python SDK client fix https://github.com/alerta/python-alerta-client/pull/146).