### PR TITLE
Add flag to disable history on value change

### DIFF
--- a/alerta/models/alert.py
+++ b/alerta/models/alert.py
@@ -250,7 +250,7 @@ class Alert(object):
                 change_type="status",
                 update_time=self.create_time
             )
-        elif self.value != previous_value:
+        elif current_app.config['HISTORY_ON_VALUE_CHANGE'] and self.value != previous_value:
             history = History(
                 id=self.id,
                 event=self.event,

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -23,6 +23,7 @@ SECRET_KEY = 'changeme'
 QUERY_LIMIT = 1000
 DEFAULT_PAGE_SIZE = QUERY_LIMIT  # maximum number of alerts returned by a single query
 HISTORY_LIMIT = 100  # cap the number of alert history entries
+HISTORY_ON_VALUE_CHANGE = True  # history entry for duplicate alerts if value changes
 
 # MongoDB
 MONGO_URI = 'mongodb://localhost:27017/monitoring'


### PR DESCRIPTION
Setting `HISTORY_ON_VALUE_CHANGE` to `False` should prevent this from now on...

![](https://files.gitter.im/alerta/chat/X0lE/Screen-Shot-2018-09-06-at-18.38.15.png)
