### PR TITLE
Telegram webhook no callback query is 200 OK

### DIFF
--- a/alerta/webhooks/telegram.py
+++ b/alerta/webhooks/telegram.py
@@ -89,4 +89,4 @@ def telegram():
         send_message_reply(alert, action, user, data)
         return jsonify(status="ok")
     else:
-        return jsonify(status="error", message="no callback_query in Telegram message"), 400
+        return jsonify(status="ok", message="no callback_query in Telegram message")


### PR DESCRIPTION
Not receiving a "callback_query" in the webhook payload for a Telegram update is not an error. It just means there's nothing for Alerta to do. For a full list of the type of updates that could be sent by the Telegram webhook see https://core.telegram.org/bots/api#update

Fixes #616