### PR TITLE
Fix get_history() sort order

### DIFF
--- a/alerta/database/backends/mongodb/base.py
+++ b/alerta/database/backends/mongodb/base.py
@@ -434,8 +434,9 @@ class Backend(Database):
             {'$unwind': '$history'},
             {'$match': query.where},
             {'$project': fields},
-            {'$limit': current_app.config['HISTORY_LIMIT']},
-            {'$sort': {'history.updateTime': 1}}
+            {'$sort': {'history.updateTime': -1}},
+            {'$skip': (page-1)*page_size},
+            {'$limit': page_size},
         ]
 
         responses = g.db.alerts.aggregate(pipeline)

--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -331,6 +331,7 @@ class Backend(Database):
             SELECT resource, environment, service, "group", tags, attributes, origin, customer,
                    history, h.* from alerts, unnest(history[1:{limit}]) h
              WHERE {where}
+          ORDER BY update_time DESC
         """.format(where=query.where, limit=current_app.config['HISTORY_LIMIT'])
         Record = namedtuple("Record", ['id', 'resource', 'event', 'environment', 'severity', 'status', 'service',
                                        'group', 'value', 'text', 'tags', 'attributes', 'origin', 'update_time',


### PR DESCRIPTION
Alert history should be sort by update_time descending. And on MongoDB the query results shouldn't be limited by `HISTORY_LIMIT` (which limits the number of individual history entries per alert) but by `PAGE_SIZE` which limits the total number of results.

Fixes #637 