### PR TITLE
Add support for paging alert history endpoint

### DIFF
--- a/alerta/views/alerts.py
+++ b/alerta/views/alerts.py
@@ -276,7 +276,8 @@ def search_alerts():
 @jsonp
 def history():
     query = qb.from_params(request.args)
-    history = Alert.get_history(query)
+    paging = Page.from_params(request.args, items=0)
+    history = Alert.get_history(query, paging.page, paging.page_size)
 
     if history:
         return jsonify(


### PR DESCRIPTION


```
$ http ':8080/alerts/history?page=2&page-size=3'
HTTP/1.0 200 OK
Access-Control-Allow-Origin: http://localhost.alerta.io:8000
Content-Encoding: gzip
Content-Length: 444
Content-Type: application/json
Date: Wed, 12 Sep 2018 20:30:08 GMT
Server: Werkzeug/0.14.1 Python/3.7.0
Vary: Origin, Accept-Encoding

{
    "history": [
        {
            "attributes": {
                "ip": "127.0.0.1"
            },
            "customer": null,
            "environment": "Development",
            ...
```