### PR TITLE
Add support for wildcard local CORS origins

### DIFF
--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -85,7 +85,8 @@ CORS_ORIGINS = [
     # 'http://explorer.alerta.io',
     'http://localhost',
     'http://localhost:8000',
-    'http://localhost.alerta.io:8000'
+    'http://local.alerta.io:8000',
+    'http://*.local.alerta.io:8000'
 ]
 CORS_SUPPORTS_CREDENTIALS = AUTH_REQUIRED
 


### PR DESCRIPTION
There are corresponding A record DNS entries in AWS Route 53 to support these development local loopback addresses...
```
$ dig *.local.alerta.io

; <<>> DiG 9.10.6 <<>> *.local.alerta.io
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 30184
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;*.local.alerta.io.		IN	A

;; ANSWER SECTION:
*.local.alerta.io.	300	IN	A	127.0.0.1

;; Query time: 7 msec
;; SERVER: 192.168.1.1#53(192.168.1.1)
;; WHEN: Thu Sep 13 23:08:45 CEST 2018
;; MSG SIZE  rcvd: 62
```

<img width="670" alt="screen shot 2018-09-13 at 23 05 40" src="https://user-images.githubusercontent.com/615057/45516026-2baecf00-b7aa-11e8-8ca7-8db9b1ffe97e.png">
<img width="638" alt="screen shot 2018-09-13 at 23 05 32" src="https://user-images.githubusercontent.com/615057/45516027-2baecf00-b7aa-11e8-8a53-6afbc31b65bd.png">
