### PR TITLE
Use regex in CORS Origins for local testing

### DIFF
--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -85,8 +85,7 @@ CORS_ORIGINS = [
     # 'http://explorer.alerta.io',
     'http://localhost',
     'http://localhost:8000',
-    'http://local.alerta.io:8000',
-    'http://*.local.alerta.io:8000'
+    r'https?://\w*\.?local\.alerta\.io:?\d*/?.*'  # => http(s)://*.local.alerta.io:<port>
 ]
 CORS_SUPPORTS_CREDENTIALS = AUTH_REQUIRED
 


### PR DESCRIPTION
Regex...
```
http(s)://*.local.alerta.io:<port>
```

**Examples**
```
http://local.alerta.io:8000/
http://api.local.alerta.io:8080/
https://ssl.local.alerta.io:8443/
```