### PR TITLE
Add support for web UI color settings

### DIFF
--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -107,6 +107,26 @@ SEVERITY_MAP = {
 DEFAULT_NORMAL_SEVERITY = 'normal'  # 'normal', 'ok', 'cleared'
 DEFAULT_PREVIOUS_SEVERITY = 'indeterminate'
 
+COLOR_MAP = {
+    'severity': {
+        'security': 'blue',
+        'critical': 'red',
+        'major': 'orange',
+        'minor': 'yellow',
+        'warning': '#1E90FF',
+        'indeterminate': 'lightblue',
+        'cleared': '#00CC00',
+        'normal': '#00CC00',
+        'ok': '#00CC00',
+        'informational': '#00CC00',
+        'debug': '#7554BF',
+        'trace': '#7554BF',
+        'unknown': 'silver'
+    },
+    'text': 'black',
+    'highlight': 'skyblue '
+}
+
 DEFAULT_TIMEOUT = 86400
 ALERT_TIMEOUT = DEFAULT_TIMEOUT
 HEARTBEAT_TIMEOUT = DEFAULT_TIMEOUT

--- a/alerta/views/__init__.py
+++ b/alerta/views/__init__.py
@@ -46,7 +46,7 @@ def config():
         'keycloak_url': current_app.config['KEYCLOAK_URL'],
         'keycloak_realm': current_app.config['KEYCLOAK_REALM'],
         'pingfederate_url': current_app.config['PINGFEDERATE_URL'],
-        'colors': {},  # not supported yet
+        'colors': current_app.config['COLOR_MAP'],
         'severity': current_app.config['SEVERITY_MAP'],
         'dates': {
             'shortTime': 'shortTime',  # 1:39 PM


### PR DESCRIPTION
**Example alertad.conf**
```
OK_COLOR = 'lightgreen'

COLOR_MAP = {
    'severity': {
        'warning': 'purple',
        'cleared':  OK_COLOR,
        'normal': OK_COLOR,
        'ok': OK_COLOR,
        'informational': OK_COLOR
    }
}
```
**Example /config JSON response**
<img width="433" alt="screen shot 2018-09-18 at 01 46 48" src="https://user-images.githubusercontent.com/615057/45656254-bc581880-bae4-11e8-9cb4-dd46f1613eba.png">
