### PR TITLE
Add envvars to management properties endpoint

### DIFF
--- a/alerta/management/views.py
+++ b/alerta/management/views.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 import time
 
 from flask import (Response, current_app, jsonify, render_template, request,
@@ -70,6 +71,9 @@ def manifest():
 def properties():
 
     properties = ''
+
+    for k, v in os.environ.items():
+        properties += '{}: {}\n'.format(k, v)
 
     for k, v in current_app.__dict__.items():
         properties += '{}: {}\n'.format(k, v)


### PR DESCRIPTION
Useful for debugging environments where config is set using environment variables.

**Example**
```
$ http :8080/management/properties
HTTP/1.0 200 OK
Access-Control-Allow-Origin: http://localhost
Content-Length: 27222
Content-Type: text/plain
Date: Fri, 21 Sep 2018 18:57:24 GMT
Server: Werkzeug/0.14.1 Python/3.7.0
Vary: Origin

VIRTUALENVWRAPPER_SCRIPT: /usr/local/bin/virtualenvwrapper.sh
VIRTUALENVWRAPPER_PROJECT_FILENAME: .project
TERM_PROGRAM: iTerm.app
TERM: xterm-256color
SHELL: /bin/bash
TERM_PROGRAM_VERSION: 3.2.0
OLDPWD: /Users/nsatterl
TERM_SESSION_ID: w0t3p0:2793D5B4-BE84-4DEC-A175-BBC9AE241567
USER: nsatterl
VIRTUAL_ENV: /Users/nsatterl/.local/share/virtualenvs/alerta
```