### PR TITLE
Fix setting timeout=None incorrectly through API

### DIFF
--- a/alerta/models/alert.py
+++ b/alerta/models/alert.py
@@ -357,7 +357,7 @@ class Alert:
 
     # set alert status
     def set_status(self, status, text='', timeout=None):
-        self.timeout = timeout or current_app.config['ALERT_TIMEOUT']
+        timeout = timeout or current_app.config['ALERT_TIMEOUT']
         history = History(
             id=self.id,
             event=self.event,


### PR DESCRIPTION
Not sure if this is the right approach, but it's definitely broken as-is, because if I submit a status change using the API without explicitly specifying the timeout, it gets set to None, and housekeeping will fail to clean these up correctly.