### PR TITLE
Add endpoints for bulk update, tag, untag and delete alerts

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = bcrypt,bson,click,dateutil,flask,flask_compress,flask_cors,itsdangerous,jwt,ldap,pkg_resources,psycopg2,pymongo,pytz,raven,requests,saml2,setuptools,six,telepot,werkzeug
+known_third_party = bcrypt,bson,celery,click,dateutil,flask,flask_compress,flask_cors,itsdangerous,jwt,kombu,ldap,pkg_resources,psycopg2,pymongo,pytz,raven,requests,saml2,setuptools,six,telepot,werkzeug

--- a/alerta/app.py
+++ b/alerta/app.py
@@ -1,4 +1,4 @@
-
+from celery import Celery
 from flask import Flask
 from flask_compress import Compress
 from flask_cors import CORS
@@ -8,6 +8,7 @@ from alerta.database.base import Database, QueryBuilder
 from alerta.exceptions import ExceptionHandlers
 from alerta.models.alarms import AlarmModel
 from alerta.utils.config import Config
+from alerta.utils.format import register_custom_serializer
 from alerta.utils.key import ApiKeyHelper
 from alerta.utils.mailer import Mailer
 from alerta.utils.plugin import Plugins
@@ -66,3 +67,25 @@ def create_app(config_override=None, environment=None):
     mailer.register(app)
 
     return app
+
+
+def create_celery_app(app=None):
+    register_custom_serializer()
+    app = app or create_app()
+    celery = Celery(
+        app.name,
+        backend=app.config['CELERY_RESULT_BACKEND'],
+        broker=app.config['CELERY_BROKER_URL']
+    )
+    celery.conf.update(app.config)
+    TaskBase = celery.Task
+
+    class ContextTask(TaskBase):
+        abstract = True
+
+        def __call__(self, *args, **kwargs):
+            with app.app_context():
+                return TaskBase.__call__(self, *args, **kwargs)
+
+    celery.Task = ContextTask
+    return celery

--- a/alerta/database/base.py
+++ b/alerta/database/base.py
@@ -137,6 +137,20 @@ class Database(Base):
     def delete_alert(self, id):
         raise NotImplementedError
 
+    # BULK
+
+    def tag_alerts(self, query=None, tags=None):
+        raise NotImplementedError
+
+    def untag_alerts(self, query=None, tags=None):
+        raise NotImplementedError
+
+    def update_attributes_by_query(self, query=None, attributes=None):
+        raise NotImplementedError
+
+    def delete_alerts(self, query=None):
+        raise NotImplementedError
+
     # SEARCH & HISTORY
 
     def get_alerts(self, query=None, page=None, page_size=None):

--- a/alerta/models/alert.py
+++ b/alerta/models/alert.py
@@ -403,6 +403,26 @@ class Alert:
     def delete(self) -> bool:
         return db.delete_alert(self.id)
 
+    # bulk tag
+    @staticmethod
+    def tag_find_all(query, tags):
+        return db.tag_alerts(query, tags)
+
+    # bulk untag
+    @staticmethod
+    def untag_find_all(query, tags):
+        return db.untag_alerts(query, tags)
+
+    # bulk update attributes
+    @staticmethod
+    def update_attributes_find_all(query, attributes):
+        return db.update_attributes_by_query(query, attributes)
+
+    # bulk delete
+    @staticmethod
+    def delete_find_all(query=None):
+        return db.delete_alerts(query)
+
     # search alerts
     @staticmethod
     def find_all(query: Query=None, page: int=1, page_size: int=1000) -> List['Alert']:

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -24,6 +24,7 @@ ALARM_MODEL = 'ALERTA'  # 'ALERTA' (default) or 'ISA_18_2'
 
 QUERY_LIMIT = 1000
 DEFAULT_PAGE_SIZE = QUERY_LIMIT  # maximum number of alerts returned by a single query
+BULK_QUERY_LIMIT = 100000  # max number of alerts for bulk endpoints
 HISTORY_LIMIT = 100  # cap the number of alert history entries
 HISTORY_ON_VALUE_CHANGE = True  # history entry for duplicate alerts if value changes
 
@@ -39,6 +40,12 @@ POSTGRES_DB = None
 DATABASE_URL = MONGO_URI  # default: MongoDB
 DATABASE_NAME = MONGO_DATABASE or POSTGRES_DB
 DATABASE_RAISE_ON_ERROR = MONGO_RAISE_ON_ERROR  # True - terminate, False - ignore and continue
+
+CELERY_BROKER_URL = None
+CELERY_RESULT_BACKEND = None
+CELERY_ACCEPT_CONTENT = ['customjson']
+CELERY_TASK_SERIALIZER = 'customjson'
+CELERY_RESULT_SERIALIZER = 'customjson'
 
 AUTH_REQUIRED = False
 AUTH_PROVIDER = 'basic'  # basic (default), github, gitlab, google, keycloak, pingfederate, saml2

--- a/alerta/utils/tasks.py
+++ b/alerta/utils/tasks.py
@@ -1,0 +1,27 @@
+
+from alerta.app import create_celery_app
+from alerta.exceptions import RejectException
+from alerta.models.alert import Alert
+from alerta.utils.api import process_action, process_status
+
+celery = create_celery_app()
+
+
+@celery.task
+def action_alerts(alerts, action, text, timeout):
+    updated = []
+    errors = []
+    for alert_id in alerts:
+        alert = Alert.find_by_id(alert_id)
+        try:
+            severity, status = process_action(alert, action)
+            alert, status, text = process_status(alert, status, text)
+        except RejectException as e:
+            errors.append(str(e))
+            continue
+        except Exception as e:
+            errors.append(str(e))
+            continue
+
+        if alert.set_severity_and_status(severity, status, text, timeout):
+            updated.append(alert.id)

--- a/alerta/views/__init__.py
+++ b/alerta/views/__init__.py
@@ -6,7 +6,7 @@ from flask import Blueprint, request, jsonify, current_app
 
 api = Blueprint('api', __name__)
 
-from . import alerts, blackouts, customers, heartbeats, keys, permissions, users, oembed  # noqa
+from . import alerts, bulk, blackouts, customers, heartbeats, keys, permissions, users, oembed  # noqa
 
 
 @api.before_request

--- a/alerta/views/bulk.py
+++ b/alerta/views/bulk.py
@@ -1,0 +1,147 @@
+
+from flask import jsonify, request
+from flask_cors import cross_origin
+
+from alerta.app import qb
+from alerta.auth.decorators import permission
+from alerta.exceptions import ApiError, RejectException
+from alerta.models.alert import Alert
+from alerta.models.metrics import timer
+from alerta.utils.api import absolute_url, jsonp, process_status
+from alerta.utils.tasks import action_alerts
+from alerta.views.alerts import (attrs_timer, delete_timer, status_timer,
+                                 tag_timer)
+
+from . import api
+
+
+@api.route('/_bulk/task/<task_id>', methods=['OPTIONS', 'GET'])
+@cross_origin()
+@permission('read:alerts')
+@timer(status_timer)
+@jsonp
+def task_status(task_id):
+    task = action_alerts.AsyncResult(task_id)
+
+    return jsonify(status=task.status.lower(), id=task.id)
+
+
+@api.route('/_bulk/alerts/status', methods=['OPTIONS', 'PUT'])
+@cross_origin()
+@permission('write:alerts')
+@timer(status_timer)
+@jsonp
+def bulk_set_status():
+    status = request.json.get('status', None)
+    text = request.json.get('text', 'bulk status update')
+    timeout = request.json.get('timeout', None)
+
+    if not status:
+        raise ApiError("must supply 'status' as json data", 400)
+
+    query = qb.from_params(request.args)
+    alerts = Alert.find_all(query)
+
+    if not alerts:
+        raise ApiError('not found', 404)
+
+    updated = []
+    errors = []
+    for alert in alerts:
+        try:
+            alert, status, text = process_status(alert, status, text)
+        except RejectException as e:
+            errors.append(str(e))
+            continue
+        except Exception as e:
+            errors.append(str(e))
+            continue
+
+        if alert.set_status(status, text, timeout):
+            updated.append(alert.id)
+
+    if errors:
+        raise ApiError('failed to bulk set alert status', 500, errors=errors)
+    else:
+        return jsonify(status='ok', updated=updated, count=len(updated))
+
+
+@api.route('/_bulk/alerts/action', methods=['OPTIONS', 'PUT'])
+@cross_origin()
+@permission('write:alerts')
+@timer(status_timer)
+@jsonp
+def bulk_action_alert():
+    action = request.json.get('action', None)
+    text = request.json.get('text', 'bulk status update')
+    timeout = request.json.get('timeout', None)
+
+    if not action:
+        raise ApiError("must supply 'action' as json data", 400)
+
+    query = qb.from_params(request.args)
+    alerts = [alert.id for alert in Alert.find_all(query)]
+
+    if not alerts:
+        raise ApiError('not found', 404)
+
+    task = action_alerts.delay(alerts, action, text, timeout)
+
+    return jsonify(status='ok', message='{} alerts queued for action'.format(len(alerts))), 202, {'Location': absolute_url('/_bulk/task/' + task.id)}
+
+
+@api.route('/_bulk/alerts/tag', methods=['OPTIONS', 'PUT'])
+@cross_origin()
+@permission('write:alerts')
+@timer(tag_timer)
+@jsonp
+def bulk_tag_alert():
+    if not request.json.get('tags', None):
+        raise ApiError("must supply 'tags' as json list")
+
+    query = qb.from_params(request.args)
+    updated = Alert.tag_find_all(query, tags=request.json['tags'])
+
+    return jsonify(status='ok', updated=updated, count=len(updated))
+
+
+@api.route('/_bulk/alerts/untag', methods=['OPTIONS', 'PUT'])
+@cross_origin()
+@permission('write:alerts')
+@timer(tag_timer)
+@jsonp
+def bulk_untag_alert():
+    if not request.json.get('tags', None):
+        raise ApiError("must supply 'tags' as json list")
+
+    query = qb.from_params(request.args)
+    updated = Alert.untag_find_all(query, tags=request.json['tags'])
+
+    return jsonify(status='ok', updated=updated, count=len(updated))
+
+
+@api.route('/_bulk/alerts/attributes', methods=['OPTIONS', 'PUT'])
+@cross_origin()
+@permission('write:alerts')
+@timer(attrs_timer)
+@jsonp
+def bulk_update_attributes():
+    if not request.json.get('attributes', None):
+        raise ApiError("must supply 'attributes' as json data", 400)
+
+    query = qb.from_params(request.args)
+    updated = Alert.update_attributes_find_all(query, request.json['attributes'])
+
+    return jsonify(status='ok', updated=updated, count=len(updated))
+
+
+@api.route('/_bulk/alerts', methods=['OPTIONS', 'DELETE'])
+@cross_origin()
+@permission('write:alerts')
+@timer(delete_timer)
+@jsonp
+def bulk_delete_alert():
+    query = qb.from_params(request.args)
+    deleted = Alert.delete_find_all(query)
+
+    return jsonify(status='ok', deleted=deleted, count=len(deleted))

--- a/mypy.ini
+++ b/mypy.ini
@@ -21,6 +21,12 @@ ignore_missing_imports = True
 [mypy-psycopg2.*]
 ignore_missing_imports = True
 
+[mypy-celery.*]
+ignore_missing_imports = True
+
+[mypy-kombu.*]
+ignore_missing_imports = True
+
 [mypy-saml2.*]
 ignore_missing_imports = True
 

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,8 @@ setuptools.setup(
         'raven[flask]>=6.2.1',
         'pymongo>=3.0',
         'psycopg2',
+        'celery',
+        'redis',
         'requests',
         'python-dateutil',
         'pytz',


### PR DESCRIPTION
To use Redis as the task queue, add the following settings to `alertad.conf`...
```
CELERY_RESULT_BACKEND='redis://localhost:6379/0'
CELERY_BROKER_URL='redis://localhost:6379/0'
```
Then run alertad as usual...
```
$ alertad run --port 8080 --with-threads
```
Install and start `redis` server ...
```
$ brew install redis
$ redis-server
```
Run a celery worker...
```
$ celery -A alerta.utils.tasks worker --loglevel=info
```
Trigger a bulk action...
```
$ http PUT :8080/_bulk/alerts/action action=ack text='bulk action'
```
See http://flask.pocoo.org/docs/1.0/patterns/celery/

Note: Celery 4.2.1 doesn't support Python 3.7 (because of the `async` reserved word clash)