### PR TITLE
User configurable sort by lastReceiveTime or createTime

### DIFF
--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -125,6 +125,7 @@ DATE_FORMAT_SHORT_TIME = 'HH:mm'  # eg. 09:24
 DATE_FORMAT_MEDIUM_DATE = 'EEE d MMM HH:mm'  # eg. Tue 9 Oct 09:24
 DATE_FORMAT_LONG_DATE = 'd/M/yyyy h:mm:ss.sss a'  # eg. 9/10/2018 9:24:03.036 AM
 DEFAULT_AUDIO_FILE = None  # must exist on client at relative path eg. `/audio/Bike Horn.mp3'
+SORT_LIST_BY = 'lastReceiveTime'  # newest='lastReceiveTime' or oldest='-createTime' (Note: minus means reverse)
 GOOGLE_TRACKING_ID = None
 AUTO_REFRESH_INTERVAL = 5000  # ms
 

--- a/alerta/views/__init__.py
+++ b/alerta/views/__init__.py
@@ -59,6 +59,7 @@ def config():
         'audio': {
             'new': current_app.config['DEFAULT_AUDIO_FILE']
         },
+        'sort_by': current_app.config['SORT_LIST_BY'],
         'tracking_id': current_app.config['GOOGLE_TRACKING_ID'],
         'refresh_interval': current_app.config['AUTO_REFRESH_INTERVAL']
     })


### PR DESCRIPTION
Set `SORT_BY_LIST` in the Alerta API to change the time attribute used to sort the web UI. eg `lastReceiveTime` (default) or `-createTime` (note; minus means reverse sort order)

**Example**
```
SORT_LIST_BY = '-createTime'
```
Requires web console pull request https://github.com/alerta/angular-alerta-webui/pull/162