### PR TITLE
Add support for range searches to query strings

### DIFF
--- a/alerta/database/backends/mongodb/queryparser.py
+++ b/alerta/database/backends/mongodb/queryparser.py
@@ -71,6 +71,30 @@ class SearchTerm:
             return '{{ "{}": {{ "$regex": "{}" }} }}'.format(self.tokens.field[0], self.tokens.wildcard)
         if 'regex' in self.tokens:
             return '{{ "{}": {{ "$regex": "{}" }} }}'.format(self.tokens.field[0], self.tokens.regex)
+        if 'range' in self.tokens:
+            if self.tokens.range[0].lowerbound == '*':
+                lower_term = '{{}}'
+            else:
+                lower_term = '{{ "{}": {{ "{}": "{}" }} }}'.format(
+                    self.tokens.field[0],
+                    '$gte' if 'inclusive' in self.tokens.range[0] else '$gt',
+                    self.tokens.range[0].lowerbound
+                )
+            if self.tokens.range[2].upperbound == '*':
+                upper_term = '{}'
+            else:
+                upper_term = '{{ "{}": {{ "{}": "{}" }} }}'.format(
+                    self.tokens.field[0],
+                    '$lte' if 'inclusive' in self.tokens.range[2] else '$lt',
+                    self.tokens.range[2].upperbound
+                )
+            return '{{ "$and": [ {}, {} ] }}'.format(lower_term, upper_term)
+        if 'onesidedrange' in self.tokens:
+            return '{{ "{}": {{ "{}": "{}" }} }}'.format(
+                self.tokens.field[0],
+                self.tokens.onesidedrange.op,
+                self.tokens.onesidedrange.bound
+            )
         if 'subquery' in self.tokens:
             if self.tokens.field[0] != '__default_field__':
                 return '{}'.format(self.tokens.subquery[0])\
@@ -97,7 +121,8 @@ query = Forward()
 
 required_modifier = Literal('+')('required')
 prohibit_modifier = Literal('-')('prohibit')
-valid_word = Word(printables, excludeChars='?*:"()').setName('word')
+special_characters = '=><(){}[]^"~*?:\\/'
+valid_word = Word(printables, excludeChars=special_characters).setName('word')
 valid_word.setParseAction(
     lambda t: t[0].replace('\\\\', chr(127)).replace('\\', '').replace(chr(127), '\\')
 )
@@ -111,7 +136,24 @@ wildcard.setParseAction(
     lambda t: t[0].replace('?', '.?').replace('*', '.*')
 )
 regex = QuotedString('/', unquoteResults=True)('regex')
-term = (regex | wildcard | phrase | single_term)
+
+_all = Literal('*')
+lower_range = Group((LBRACK('inclusive') | LBRACE('exclusive')) + (valid_word | _all)('lowerbound'))
+upper_range = Group((valid_word | _all)('upperbound') + (RBRACK('inclusive') | RBRACE('esclusive')))
+_range = (lower_range + to_ + upper_range)('range')
+
+GT = Literal('>')
+GTE = Literal('>=')
+LT = Literal('<')
+LTE = Literal('<=')
+
+mongo_op = (GTE | GT | LTE | LT)
+mongo_op.setParseAction(
+    lambda t: t[0].replace('>=', '$gte').replace('>', '$gt').replace('<=', '$lte').replace('<', '$lt')
+)
+one_sided_range = Group(mongo_op('op') + valid_word('bound'))('onesidedrange')
+
+term = (_range | one_sided_range | regex | wildcard | phrase | single_term)
 
 clause << (Optional(field_name + COLON, default='__default_field__')('field') +
            (term('term') | Group(LPAR + query + RPAR)('subquery')))
@@ -126,9 +168,13 @@ query << infixNotation(clause,
                            (Optional(or_ | '||').setParseAction(lambda: 'OR'), 2, opAssoc.LEFT, SearchOr),
                        ])
 
-DEFAULT_FIELD = 'text'
-DEFAULT_OPERATOR = '$regex'
 
+class QueryParser:
 
-def query_parser(q):
-    return repr(query.parseString(q)[0]).replace('__default_field__', DEFAULT_FIELD).replace('__default_operator__', DEFAULT_OPERATOR)
+    DEFAULT_FIELD = 'text'
+    DEFAULT_OPERATOR = '$regex'
+
+    def parse(self, q):
+        return repr(query.parseString(q)[0])\
+            .replace('__default_field__', QueryParser.DEFAULT_FIELD)\
+            .replace('__default_operator__', QueryParser.DEFAULT_OPERATOR)

--- a/alerta/database/backends/mongodb/utils.py
+++ b/alerta/database/backends/mongodb/utils.py
@@ -11,7 +11,7 @@ from alerta.database.base import QueryBuilder
 from alerta.exceptions import ApiError
 from alerta.utils.format import DateTime
 
-from .parser import query_parser
+from .queryparser import QueryParser
 
 Query = namedtuple('Query', ['where', 'sort', 'group'])
 Query.__new__.__defaults__ = ({}, {}, 'lastReceiveTime', 'status')  # type: ignore
@@ -25,7 +25,8 @@ class QueryBuilderImpl(QueryBuilder):
         # q
         if params.get('q', None):
             try:
-                query = json.loads(query_parser(params['q']))
+                parser = QueryParser()
+                query = json.loads(parser.parse(params['q']))
             except ParseException as e:
                 raise ApiError('Failed to parse query string.', 400, [e])
         else:

--- a/alerta/database/backends/postgres/utils.py
+++ b/alerta/database/backends/postgres/utils.py
@@ -9,7 +9,7 @@ from alerta.database.base import QueryBuilder
 from alerta.exceptions import ApiError
 from alerta.utils.format import DateTime
 
-from .parser import query_parser
+from .queryparser import QueryParser
 
 Query = namedtuple('Query', ['where', 'vars', 'sort', 'group'])
 Query.__new__.__defaults__ = ('1=1', {}, 'last_receive_time', 'status')  # type: ignore
@@ -23,7 +23,8 @@ class QueryBuilderImpl(QueryBuilder):
         # q
         if params.get('q', None):
             try:
-                query = [query_parser(params['q'])]
+                parser = QueryParser()
+                query = [parser.parse(params['q'])]
                 qvars = dict()
             except ParseException as e:
                 raise ApiError('Failed to parse query string.', 400, [e])

--- a/tests/test_mongo_query.py
+++ b/tests/test_mongo_query.py
@@ -1,69 +1,69 @@
 import unittest
 
-from alerta.database.backends.mongodb.parser import query_parser
+from alerta.database.backends.mongodb.queryparser import QueryParser
 
 
 class MongoQueryTestCase(unittest.TestCase):
 
     def setUp(self):
 
-        pass
+        self.parser = QueryParser()
 
     def test_word_and_phrase_terms(self):
 
         # default field (ie. "text") contains word
         string = r'''quick'''
-        r = query_parser(string)
+        r = self.parser.parse(string)
         self.assertEqual(r, '{ "text": { "$regex": "quick" } }')
 
         # default field (ie. "text") contains phrase
         string = r'''"quick brown"'''
-        r = query_parser(string)
+        r = self.parser.parse(string)
         self.assertEqual(r, '{ "text": { "$regex": "\\"quick brown\\"" } }')
 
     def test_field_names(self):
 
         # field contains word
         string = r'''status:active'''
-        r = query_parser(string)
+        r = self.parser.parse(string)
         self.assertEqual(r, '{ "status": { "$regex": "active" } }')
 
         # field contains either words
         string = r'''title:(quick OR brown)'''
-        r = query_parser(string)
+        r = self.parser.parse(string)
         self.assertEqual(r, '{ "$or": [{ "title": { "$regex": "quick" } }, { "title": { "$regex": "brown" } }] }')
 
         # field contains either words (default operator)
         string = r'''title:(quick brown)'''
-        r = query_parser(string)
+        r = self.parser.parse(string)
         self.assertEqual(r, '{ "$or": [{ "title": { "$regex": "quick" } }, { "title": { "$regex": "brown" } }] }')
 
         # field exact match
         string = r'''author:"John Smith"'''
-        r = query_parser(string)
+        r = self.parser.parse(string)
         self.assertEqual(r, '{ "author": "John Smith" }')
 
         # # # any attribute contains word or phrase
         # # string = r'''attributes.\*:(quick brown)'''
-        # # r = query_parser(string)
+        # # r = self.parser.parse(string)
         # # self.assertEqual(r, '??')
 
         # attribute field has non-null value
         string = r'''_exists_:title'''
-        r = query_parser(string)
+        r = self.parser.parse(string)
         self.assertEqual(r, '{ "attributes.title": { "$exists": true } }')
 
     def test_wildcards(self):
 
         # ? = single character, * = one or more characters
         string = r'''text:qu?ck bro*'''
-        r = query_parser(string)
+        r = self.parser.parse(string)
         self.assertEqual(r, '{ "text": { "$regex": "qu.?ck bro.*" } }')
 
     def test_regular_expressions(self):
 
         string = r'''name:/joh?n(ath[oa]n)/'''
-        r = query_parser(string)
+        r = self.parser.parse(string)
         self.assertEqual(r, '{ "name": { "$regex": "joh?n(ath[oa]n)" } }')
 
     def test_fuzziness(self):
@@ -72,49 +72,50 @@ class MongoQueryTestCase(unittest.TestCase):
     def test_proximity_searches(self):
         pass
 
-    # def test_ranges(self):
-    #
-    #     string = r'''date:[2012-01-01 TO 2012-12-31]'''
-    #     r = query_parser(string)
-    #     self.assertEqual(r, '??')
-    #
-    #     string = r'''count:[1 TO 5]'''
-    #     r = query_parser(string)
-    #     self.assertEqual(r, '??')
-    #
-    #     string = r'''tag:{alpha TO omega}'''
-    #     r = query_parser(string)
-    #     self.assertEqual(r, '??')
-    #
-    #     string = r'''count:[10 TO *]'''
-    #     r = query_parser(string)
-    #     self.assertEqual(r, '??')
-    #
-    #     string = r''''date:{* TO 2012-01-01}'''
-    #     r = query_parser(string)
-    #     self.assertEqual(r, '??')
-    #
-    #     string = r''''count:[1 TO 5}'''
-    #     r = query_parser(string)
-    #     self.assertEqual(r, '??')
-    #
-    # def test_unbounded_ranges(self):
-    #
-    #     string = r'''age:>10'''
-    #     r = query_parser(string)
-    #     self.assertEqual(r, '??')
-    #
-    #     string = r'''age:>=10'''
-    #     r = query_parser(string)
-    #     self.assertEqual(r, '??')
-    #
-    #     string = r'''age:<10'''
-    #     r = query_parser(string)
-    #     self.assertEqual(r, '??')
-    #
-    #     string = r'''age:<=10'''
-    #     r = query_parser(string)
-    #     self.assertEqual(r, '??')
+    def test_ranges(self):
+
+        string = r'''date:[2012-01-01 TO 2012-12-31]'''
+        r = self.parser.parse(string)
+        self.assertEqual(
+            r, '{ "$and": [ { "date": { "$gte": "2012-01-01" } }, { "date": { "$lte": "2012-12-31" } } ] }')
+
+        string = r'''count:[1 TO 5]'''
+        r = self.parser.parse(string)
+        self.assertEqual(r, '{ "$and": [ { "count": { "$gte": "1" } }, { "count": { "$lte": "5" } } ] }')
+
+        string = r'''tag:{alpha TO omega}'''
+        r = self.parser.parse(string)
+        self.assertEqual(r, '{ "$and": [ { "tag": { "$gt": "alpha" } }, { "tag": { "$lt": "omega" } } ] }')
+
+        string = r'''count:[10 TO *]'''
+        r = self.parser.parse(string)
+        self.assertEqual(r, '{ "$and": [ { "count": { "$gte": "10" } }, {} ] }')
+
+        string = r'''date:{* TO 2012-01-01}'''
+        r = self.parser.parse(string)
+        self.assertEqual(r, '{ "$and": [ {{}}, { "date": { "$lt": "2012-01-01" } } ] }')
+
+        string = r'''count:[1 TO 5}'''
+        r = self.parser.parse(string)
+        self.assertEqual(r, '{ "$and": [ { "count": { "$gte": "1" } }, { "count": { "$lt": "5" } } ] }')
+
+    def test_unbounded_ranges(self):
+
+        string = r'''age:>10'''
+        r = self.parser.parse(string)
+        self.assertEqual(r, '{ "age": { "$gt": "10" } }')
+
+        string = r'''age:>=10'''
+        r = self.parser.parse(string)
+        self.assertEqual(r, '{ "age": { "$gte": "10" } }')
+
+        string = r'''age:<10'''
+        r = self.parser.parse(string)
+        self.assertEqual(r, '{ "age": { "$lt": "10" } }')
+
+        string = r'''age:<=10'''
+        r = self.parser.parse(string)
+        self.assertEqual(r, '{ "age": { "$lte": "10" } }')
 
     def test_boosting(self):
         pass
@@ -126,12 +127,12 @@ class MongoQueryTestCase(unittest.TestCase):
 
         # field exact match
         string = r'''(quick OR brown) AND fox'''
-        r = query_parser(string)
+        r = self.parser.parse(string)
         self.assertEqual(
             r, '{ "$and": [{ "$or": [{ "text": { "$regex": "quick" } }, { "text": { "$regex": "brown" } }] }, { "text": { "$regex": "fox" } }] }')
 
         # field exact match
         string = r'''status:(active OR pending) title:(full text search)'''
-        r = query_parser(string)
+        r = self.parser.parse(string)
         self.assertEqual(
             r, '{ "$or": [{ "$or": [{ "status": { "$regex": "active" } }, { "status": { "$regex": "pending" } }] }, { "$or": [{ "title": { "$regex": "full" } }, { "title": { "$regex": "text" } }] }] }')

--- a/tests/test_postgres_query.py
+++ b/tests/test_postgres_query.py
@@ -1,69 +1,69 @@
 import unittest
 
-from alerta.database.backends.postgres.parser import query_parser
+from alerta.database.backends.postgres.queryparser import QueryParser
 
 
 class PostgresQueryTestCase(unittest.TestCase):
 
     def setUp(self):
 
-        pass
+        self.parser = QueryParser()
 
     def test_word_and_phrase_terms(self):
 
         # default field (ie. "text") contains word
         string = r'''quick'''
-        r = query_parser(string)
+        r = self.parser.parse(string)
         self.assertEqual(r, '"text" ILIKE \'%%quick%%\'')
 
         # default field (ie. "text") contains phrase
         string = r'''"quick brown"'''
-        r = query_parser(string)
+        r = self.parser.parse(string)
         self.assertEqual(r, '"text" ~* \'quick brown\'')
 
     def test_field_names(self):
 
         # field contains word
         string = r'''status:active'''
-        r = query_parser(string)
+        r = self.parser.parse(string)
         self.assertEqual(r, '"status" ILIKE \'%%active%%\'')
 
         # field contains either words
         string = r'''title:(quick OR brown)'''
-        r = query_parser(string)
+        r = self.parser.parse(string)
         self.assertEqual(r, '("title" ILIKE \'%%quick%%\' OR "title" ILIKE \'%%brown%%\')')
 
         # field contains either words (default operator)
         string = r'''title:(quick brown)'''
-        r = query_parser(string)
+        r = self.parser.parse(string)
         self.assertEqual(r, '("title" ILIKE \'%%quick%%\' OR "title" ILIKE \'%%brown%%\')')
 
         # field exact match
         string = r'''author:"John Smith"'''
-        r = query_parser(string)
+        r = self.parser.parse(string)
         self.assertEqual(r, '"author"=\'John Smith\'')
 
         # # any attribute contains word or phrase
         # string = r'''attributes.\*:(quick brown)'''
-        # r = query_parser(string)
+        # r = self.parser.parse(string)
         # self.assertEqual(r, '??')
 
         # attribute field has non-null value
         string = r'''_exists_:title'''
-        r = query_parser(string)
+        r = self.parser.parse(string)
         self.assertEqual(r, '"attributes"::jsonb ? \'title\'')
 
     def test_wildcards(self):
 
         # ? = single character, * = one or more characters
         string = r'''text:qu?ck bro*'''
-        r = query_parser(string)
+        r = self.parser.parse(string)
         self.assertEqual(r, '"text" ~* \'qu.?ck bro.*\'')
 
     def test_regular_expressions(self):
 
         string = r'''name:/joh?n(ath[oa]n)/'''
-        r = query_parser(string)
+        r = self.parser.parse(string)
         self.assertEqual(r, '"name" ~* \'joh?n(ath[oa]n)\'')
 
     def test_fuzziness(self):
@@ -72,49 +72,49 @@ class PostgresQueryTestCase(unittest.TestCase):
     def test_proximity_searches(self):
         pass
 
-    # def test_ranges(self):
-    #
-    #     string = r'''date:[2012-01-01 TO 2012-12-31]'''
-    #     r = query_parser(string)
-    #     self.assertEqual(r, '??')
-    #
-    #     string = r'''count:[1 TO 5]'''
-    #     r = query_parser(string)
-    #     self.assertEqual(r, '??')
-    #
-    #     string = r'''tag:{alpha TO omega}'''
-    #     r = query_parser(string)
-    #     self.assertEqual(r, '??')
-    #
-    #     string = r'''count:[10 TO *]'''
-    #     r = query_parser(string)
-    #     self.assertEqual(r, '??')
-    #
-    #     string = r''''date:{* TO 2012-01-01}'''
-    #     r = query_parser(string)
-    #     self.assertEqual(r, '??')
-    #
-    #     string = r''''count:[1 TO 5}'''
-    #     r = query_parser(string)
-    #     self.assertEqual(r, '??')
-    #
-    # def test_unbounded_ranges(self):
-    #
-    #     string = r'''age:>10'''
-    #     r = query_parser(string)
-    #     self.assertEqual(r, '??')
-    #
-    #     string = r'''age:>=10'''
-    #     r = query_parser(string)
-    #     self.assertEqual(r, '??')
-    #
-    #     string = r'''age:<10'''
-    #     r = query_parser(string)
-    #     self.assertEqual(r, '??')
-    #
-    #     string = r'''age:<=10'''
-    #     r = query_parser(string)
-    #     self.assertEqual(r, '??')
+    def test_ranges(self):
+
+        string = r'''date:[2012-01-01 TO 2012-12-31]'''
+        r = self.parser.parse(string)
+        self.assertEqual(r, '("date" >= \'2012-01-01\' AND "date" <= \'2012-12-31\')')
+
+        string = r'''count:[1 TO 5]'''
+        r = self.parser.parse(string)
+        self.assertEqual(r, '("count" >= \'1\' AND "count" <= \'5\')')
+
+        string = r'''tag:{alpha TO omega}'''
+        r = self.parser.parse(string)
+        self.assertEqual(r, '("tag" > \'alpha\' AND "tag" < \'omega\')')
+
+        string = r'''count:[10 TO *]'''
+        r = self.parser.parse(string)
+        self.assertEqual(r, '("count" >= \'10\' AND 1=1)')
+
+        string = r'''date:{* TO 2012-01-01}'''
+        r = self.parser.parse(string)
+        self.assertEqual(r, '(1=1 AND "date" < \'2012-01-01\')')
+
+        string = r'''count:[1 TO 5}'''
+        r = self.parser.parse(string)
+        self.assertEqual(r, '("count" >= \'1\' AND "count" < \'5\')')
+
+    def test_unbounded_ranges(self):
+
+        string = r'''age:>10'''
+        r = self.parser.parse(string)
+        self.assertEqual(r, '("age" > \'10\')')
+
+        string = r'''age:>=10'''
+        r = self.parser.parse(string)
+        self.assertEqual(r, '("age" >= \'10\')')
+
+        string = r'''age:<10'''
+        r = self.parser.parse(string)
+        self.assertEqual(r, '("age" < \'10\')')
+
+        string = r'''age:<=10'''
+        r = self.parser.parse(string)
+        self.assertEqual(r, '("age" <= \'10\')')
 
     def test_boosting(self):
         pass
@@ -126,10 +126,11 @@ class PostgresQueryTestCase(unittest.TestCase):
 
         # field exact match
         string = r'''(quick OR brown) AND fox'''
-        r = query_parser(string)
+        r = self.parser.parse(string)
         self.assertEqual(r, '(("text" ILIKE \'%%quick%%\' OR "text" ILIKE \'%%brown%%\') AND "text" ILIKE \'%%fox%%\')')
 
         # field exact match
         string = r'''status:(active OR pending) title:(full text search)'''
-        r = query_parser(string)
-        self.assertEqual(r, '(("status" ILIKE \'%%active%%\' OR "status" ILIKE \'%%pending%%\') OR ("title" ILIKE \'%%full%%\' OR "title" ILIKE \'%%text%%\'))')
+        r = self.parser.parse(string)
+        self.assertEqual(
+            r, '(("status" ILIKE \'%%active%%\' OR "status" ILIKE \'%%pending%%\') OR ("title" ILIKE \'%%full%%\' OR "title" ILIKE \'%%text%%\'))')


### PR DESCRIPTION
See #712 

**Examples Range Queries**
```
date:[2012-01-01 TO 2012-12-31]
count:[1 TO 5]
tag:{alpha TO omega}
count:[10 TO *]
```

**Example One-sided Range Queries**
```
age:>10
age:>=10
age:<10
age:<=10
```

Note: Range queries based on severity levels are not currently supported.