### PR TITLE
Support python string formats in Prometheus rules

### DIFF
--- a/alerta/webhooks/prometheus.py
+++ b/alerta/webhooks/prometheus.py
@@ -58,7 +58,7 @@ def parse_prometheus(alert: JSON, external_url: str) -> Alert:
 
     # labels
     resource = labels.pop('exported_instance', None) or labels.pop('instance', 'n/a')
-    event = labels.pop('alertname')
+    event = labels.pop('event', None) or labels.pop('alertname')
     environment = labels.pop('environment', 'Production')
     correlate = labels.pop('correlate').split(',') if 'correlate' in labels else None
     service = labels.pop('service', '').split(',')

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -305,12 +305,15 @@ class WebhooksTestCase(unittest.TestCase):
                     {
                         "status": "firing",
                         "labels": {
-                            "alertname": "thing_dead"
+                            "alertname": "thing_dead",
+                            "severity": "critical"
                         },
                         "annotations": {
                             "description": "No things have been recorded for over 10 minutes. Something terrible is happening.",
                             "severity": "critical",
-                            "summary": "No things for over 10 minutes"
+                            "summary": "No things for over 10 minutes",
+                            "runbookBad": "https://internal.myorg.net/wiki/alerts/{app}/{alertname}",
+                            "runbookGood": "https://internal.myorg.net/wiki/alerts/{alertname}"
                         },
                         "startsAt": "2017-08-03T15:17:37.804-04:00",
                         "endsAt": "0001-01-01T00:00:00Z",
@@ -613,10 +616,14 @@ class WebhooksTestCase(unittest.TestCase):
         self.assertEqual(data['alert']['resource'], 'n/a')
         self.assertEqual(data['alert']['event'], 'thing_dead')
         self.assertEqual(data['alert']['status'], 'open')
-        self.assertEqual(data['alert']['severity'], 'warning')
+        self.assertEqual(data['alert']['severity'], 'critical')
         self.assertEqual(data['alert']['timeout'], 86400)
         self.assertEqual(data['alert']['createTime'], '2017-08-03T19:17:37.804Z')
         self.assertEqual(data['alert']['attributes']['ip'], '192.168.1.1')
+        self.assertEqual(data['alert']['attributes']['runbookBad'],
+                         'https://internal.myorg.net/wiki/alerts/{app}/{alertname}')
+        self.assertEqual(data['alert']['attributes']['runbookGood'],
+                         'https://internal.myorg.net/wiki/alerts/thing_dead')
 
     def test_riemann_webhook(self):
 


### PR DESCRIPTION
Support python templating in Prometheus rules files so that labels and annotations can refer to labels that aren't available as `$labels.whatever`.

**Example label for compound event name**
```
  # disk space alert (with resource=<instance> event=disk_util:<mountpoint>
  - alert: disk_util
    expr: (node_filesystem_size_bytes - node_filesystem_free_bytes) * 100 / node_filesystem_size_bytes > 5
    labels:
      instance: '{{ $labels.instance }}'
      event: '{alertname}:{{ $labels.mountpoint }}'  # python templating rendered by Alerta
    annotations:
      value: '{{ humanize $value }}%'
```
**Example annotation for Runbook URL**
```
  # service availability alert
  - alert: service_down
    expr: up == 0
    labels:
      service: Platform
      severity: major
      correlate: service_up,service_down
    annotations:
      description: Service {{ $labels.instance }} is unavailable.
      value: DOWN ({{ $value }})
      runbook: https://internal.myorg.net/wiki/alerts/{app}/{alertname}
```

This is either genius or a very bad idea. 😕  Fixes alerta/prometheus-config/issues/15