### PR TITLE
Show custom webhooks in list of rules

### DIFF
--- a/alerta/utils/webhook.py
+++ b/alerta/utils/webhook.py
@@ -2,12 +2,18 @@
 from pkg_resources import iter_entry_points
 
 
+class WebhookRule:
+    def __init__(self, rule, endpoint, methods):
+        self.rule = rule
+        self.endpoint = endpoint
+        self.methods = methods
+
+
 class CustomWebhooks:
     def __init__(self):
         self.webhooks = dict()
 
     def register(self, app):
-
         for ep in iter_entry_points('alerta.webhooks'):
             try:
                 webhook = ep.load()
@@ -15,3 +21,11 @@ class CustomWebhooks:
                     self.webhooks[ep.name] = webhook()
             except Exception as e:
                 app.log.warn('Failed to load custom webhook {} - {}'.format(ep.name, e))
+
+    def iter_rules(self):
+        return iter([
+            WebhookRule(
+                rule='/webhooks/{}'.format(name),
+                endpoint='webhooks.{}'.format(name),
+                methods=['POST', 'GET']
+            ) for name, ep in self.webhooks.items()])

--- a/alerta/views/__init__.py
+++ b/alerta/views/__init__.py
@@ -1,5 +1,5 @@
 
-from alerta.app import alarm_model
+from alerta.app import alarm_model, custom_webhooks
 from alerta.exceptions import ApiError
 from alerta.utils.response import absolute_url
 from flask import Blueprint, request, jsonify, current_app
@@ -23,12 +23,21 @@ def before_request():
 @api.route('/', methods=['OPTIONS', 'GET'])
 def index():
     links = []
+
     for rule in current_app.url_map.iter_rules():
         links.append({
             'rel': rule.endpoint,
             'href': absolute_url(rule.rule),
             'method': ','.join([m for m in rule.methods if m not in ['HEAD', 'OPTIONS']])
         })
+
+    for rule in custom_webhooks.iter_rules():
+        links.append({
+            'rel': rule.endpoint,
+            'href': absolute_url(rule.rule),
+            'method': ','.join(rule.methods)
+        })
+
     return jsonify(status='ok', uri=absolute_url(), data={'description': 'Alerta API'}, links=sorted(links, key=lambda k: k['href']))
 
 


### PR DESCRIPTION
A custom webhook should show up just like any other rule when hitting the API index URL (`/`)...
```
        {
            "href": "http://localhost:8080/webhooks/riemann",
            "method": "POST",
            "rel": "webhooks.riemann"
        },
        {
            "href": "http://localhost:8080/webhooks/sentry",
            "method": "POST,GET",
            "rel": "webhooks.sentry"
        },
        {
            "href": "http://localhost:8080/webhooks/serverdensity",
            "method": "POST",
            "rel": "webhooks.serverdensity"
        },
        {
```
Note: In the above list "sentry" is the custom webhook.