### PR TITLE
Add audit trail using blinker signals

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = bcrypt,bson,celery,click,dateutil,flask,flask_compress,flask_cors,itsdangerous,jwt,kombu,ldap,pkg_resources,psycopg2,pymongo,pyparsing,pytz,raven,requests,saml2,setuptools,six,telepot,werkzeug
+known_third_party = bcrypt,blinker,bson,celery,click,dateutil,flask,flask_compress,flask_cors,itsdangerous,jwt,kombu,ldap,pkg_resources,psycopg2,pymongo,pyparsing,pytz,raven,requests,saml2,setuptools,six,telepot,werkzeug

--- a/alerta/app.py
+++ b/alerta/app.py
@@ -9,6 +9,7 @@ from werkzeug.contrib.fixers import ProxyFix
 from alerta.database.base import Database, QueryBuilder
 from alerta.exceptions import ExceptionHandlers
 from alerta.models.alarms import AlarmModel
+from alerta.utils.audit import AuditTrail
 from alerta.utils.config import Config
 from alerta.utils.key import ApiKeyHelper
 from alerta.utils.mailer import Mailer
@@ -16,6 +17,7 @@ from alerta.utils.plugin import Plugins
 from alerta.utils.webhook import CustomWebhooks
 
 config = Config()
+audit = AuditTrail()
 alarm_model = AlarmModel()
 
 cors = CORS()
@@ -40,6 +42,7 @@ def create_app(config_override: Dict[str, Any]=None, environment: str=None) -> F
     if app.config['USE_PROXYFIX']:
         app.wsgi_app = ProxyFix(app.wsgi_app)
 
+    audit.init_app(app)
     alarm_model.init_app(app)
 
     cors.init_app(app)

--- a/alerta/auth/basic_ldap.py
+++ b/alerta/auth/basic_ldap.py
@@ -5,7 +5,9 @@ from flask_cors import cross_origin
 
 from alerta.auth.utils import create_token, get_customers
 from alerta.exceptions import ApiError
+from alerta.models.permission import Permission
 from alerta.models.user import User
+from alerta.utils.audit import audit_trail
 
 from . import auth
 
@@ -53,7 +55,11 @@ def login():
     customers = get_customers(user.email, groups=[user.domain])
     user.update_last_login()
 
+    audit_trail.send(current_app._get_current_object(), event='basic-ldap-login', message='user login via LDAP',
+                     user=user.email, customers=customers, scopes=Permission.lookup(login, groups=user.roles),
+                     resource_id=user.id, type='user', request=request)
+
     # Generate token
-    token = create_token(user.id, user.name, user.email, provider='basic_ldap', customers=customers,
-                         roles=user.roles, email=user.email, email_verified=user.email_verified)
+    token = create_token(user_id=user.id, name=user.name, login=user.email, provider='basic_ldap',
+                         customers=customers, roles=user.roles, email=user.email, email_verified=user.email_verified)
     return jsonify(token=token.tokenize)

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -49,6 +49,9 @@ CELERY_ACCEPT_CONTENT = ['customjson']
 CELERY_TASK_SERIALIZER = 'customjson'
 CELERY_RESULT_SERIALIZER = 'customjson'
 
+AUDIT_LOG = None  # set to True to log to application logger
+AUDIT_URL = None  # send audit log events via webhook URL
+
 AUTH_REQUIRED = False
 AUTH_PROVIDER = 'basic'  # basic (default), github, gitlab, google, keycloak, pingfederate, saml2
 ADMIN_USERS = []  # type: List[str]

--- a/alerta/utils/audit.py
+++ b/alerta/utils/audit.py
@@ -1,0 +1,70 @@
+import json
+from datetime import datetime
+from typing import Any, List
+from uuid import uuid4
+
+import blinker
+import requests
+from flask import Flask
+
+from alerta.utils.format import CustomJSONEncoder
+
+audit_signals = blinker.Namespace()
+
+audit_trail = audit_signals.signal('audit')
+
+
+class AuditTrail:
+
+    def __init__(self, app: Flask=None) -> None:
+        self.app = app
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app: Flask) -> None:
+        if app.config['AUDIT_LOG']:
+            audit_trail.connect(self.log_response, app)
+
+        self.audit_url = app.config['AUDIT_URL']
+        if self.audit_url:
+            audit_trail.connect(self.webhook_response, app)
+
+    def log_response(self, app: Flask, event: str, message: str, user: str, customers: List[str],
+                     scopes: List[str], resource_id: str, type: str, request: Any, **extra: Any) -> None:
+        app.logger.debug(self._fmt(event, message, user, customers, scopes, resource_id, type, request, **extra))
+
+    def webhook_response(self, app: Flask, event: str, message: str, user: str, customers: List[str],
+                         scopes: List[str], resource_id: str, type: str, request: Any, **extra: Any) -> None:
+        payload = self._fmt(event, message, user, customers, scopes, resource_id, type, request, **extra)
+        try:
+            requests.post(self.audit_url, data=payload, timeout=2)
+        except Exception as e:
+            app.logger.warning('Failed to send audit log entry to "{}" - {}'.format(self.audit_url, str(e)))
+
+    @staticmethod
+    def _fmt(event: str, message: str, user: str, customers: List[str], scopes: List[str],
+             resource_id: str, type: str, request: Any, **extra: Any) -> str:
+        return json.dumps({
+            'id': str(uuid4()),
+            '@timestamp': datetime.utcnow(),
+            'event': event,
+            'message': message,
+            'user': {
+                'id': user,
+                'customers': customers,
+                'scopes': scopes
+            },
+            'resource': {
+                'id': resource_id,
+                'type': type
+            },
+            'request': {
+                'endpoint': request.endpoint,
+                'method': request.method,
+                'url': request.url,
+                'args': request.args.to_dict(),
+                'data': request.get_data(as_text=True),
+                'ipAddress': request.remote_addr
+            },
+            'extra': extra
+        }, cls=CustomJSONEncoder)

--- a/alerta/views/blackouts.py
+++ b/alerta/views/blackouts.py
@@ -1,5 +1,5 @@
 
-from flask import g, jsonify, request
+from flask import current_app, g, jsonify, request
 from flask_cors import cross_origin
 
 from alerta.app import qb
@@ -8,6 +8,7 @@ from alerta.exceptions import ApiError
 from alerta.models.blackout import Blackout
 from alerta.models.enums import Scope
 from alerta.utils.api import assign_customer
+from alerta.utils.audit import audit_trail
 from alerta.utils.response import absolute_url, jsonp
 
 from . import api
@@ -34,6 +35,9 @@ def create_blackout():
         blackout = blackout.create()
     except Exception as e:
         raise ApiError(str(e), 500)
+
+    audit_trail.send(current_app._get_current_object(), event='blackout-created', message='', user=g.user,
+                     customers=g.customers, scopes=g.scopes, resource_id=blackout.id, type='blackout', request=request)
 
     if blackout:
         return jsonify(status='ok', id=blackout.id, blackout=blackout.serialize), 201, {'Location': absolute_url('/blackout/' + blackout.id)}
@@ -74,6 +78,9 @@ def delete_blackout(blackout_id):
 
     if not blackout:
         raise ApiError('not found', 404)
+
+    audit_trail.send(current_app._get_current_object(), event='blackout-deleted', message='', user=g.user,
+                     customers=g.customers, scopes=g.scopes, resource_id=blackout.id, type='blackout', request=request)
 
     if blackout.delete():
         return jsonify(status='ok')

--- a/alerta/views/keys.py
+++ b/alerta/views/keys.py
@@ -7,6 +7,7 @@ from alerta.models.enums import Scope
 from alerta.models.key import ApiKey
 from alerta.models.permission import Permission
 from alerta.utils.api import assign_customer
+from alerta.utils.audit import audit_trail
 from alerta.utils.response import jsonp
 
 from . import api
@@ -41,6 +42,9 @@ def create_key():
         key = key.create()
     except Exception as e:
         raise ApiError(str(e), 500)
+
+    audit_trail.send(current_app._get_current_object(), event='apikey-created', message='', user=g.user,
+                     customers=g.customers, scopes=g.scopes, resource_id=key.id, type='apikey', request=request)
 
     if key:
         return jsonify(status='ok', key=key.key, data=key.serialize), 201
@@ -86,6 +90,9 @@ def delete_key(key):
 
     if not key:
         raise ApiError('not found', 404)
+
+    audit_trail.send(current_app._get_current_object(), event='apikey-deleted', message='', user=g.user,
+                     customers=g.customers, scopes=g.scopes, resource_id=key.id, type='apikey', request=request)
 
     if key.delete():
         return jsonify(status='ok')

--- a/alerta/views/permissions.py
+++ b/alerta/views/permissions.py
@@ -1,11 +1,12 @@
 
-from flask import g, jsonify, request
+from flask import current_app, g, jsonify, request
 from flask_cors import cross_origin
 
 from alerta.auth.decorators import permission
 from alerta.exceptions import ApiError
 from alerta.models.enums import Scope
 from alerta.models.permission import Permission
+from alerta.utils.audit import audit_trail
 from alerta.utils.response import jsonp
 
 from . import api
@@ -30,6 +31,9 @@ def create_perm():
         perm = perm.create()
     except Exception as e:
         raise ApiError(str(e), 500)
+
+    audit_trail.send(current_app._get_current_object(), event='permission-created', message='', user=g.user,
+                     customers=g.customers, scopes=g.scopes, resource_id=perm.id, type='permission', request=request)
 
     if perm:
         return jsonify(status='ok', id=perm.id, permission=perm.serialize), 201
@@ -68,6 +72,9 @@ def delete_perm(perm_id):
 
     if not perm:
         raise ApiError('not found', 404)
+
+    audit_trail.send(current_app._get_current_object(), event='permission-deleted', message='', user=g.user,
+                     customers=g.customers, scopes=g.scopes, resource_id=perm.id, type='permission', request=request)
 
     if perm.delete():
         return jsonify(status='ok')

--- a/alerta/views/users.py
+++ b/alerta/views/users.py
@@ -7,6 +7,7 @@ from alerta.auth.utils import not_authorized
 from alerta.exceptions import ApiError
 from alerta.models.enums import Scope
 from alerta.models.user import User
+from alerta.utils.audit import audit_trail
 from alerta.utils.response import jsonp
 
 from . import api
@@ -38,6 +39,9 @@ def create_user():
     if current_app.config['EMAIL_VERIFICATION'] and not user.email_verified:
         user.send_confirmation()
 
+    audit_trail.send(current_app._get_current_object(), event='user-created', message='', user=g.user,
+                     customers=g.customers, scopes=g.scopes, resource_id=user.id, type='user', request=request)
+
     if user:
         return jsonify(status='ok', id=user.id, user=user.serialize), 201
     else:
@@ -59,6 +63,9 @@ def update_user(user_id):
 
     if 'email' in request.json and User.find_by_email(request.json['email']):
         raise ApiError('user with email already exists', 409)
+
+    audit_trail.send(current_app._get_current_object(), event='user-updated', message='', user=g.user,
+                     customers=g.customers, scopes=g.scopes, resource_id=user.id, type='user', request=request)
 
     if user.update(**request.json):
         return jsonify(status='ok')
@@ -87,6 +94,9 @@ def update_me():
     if 'email' in request.json and User.find_by_email(request.json['email']):
         raise ApiError('user with email already exists', 409)
 
+    audit_trail.send(current_app._get_current_object(), event='user-me-updated', message='', user=g.user,
+                     customers=g.customers, scopes=g.scopes, resource_id=user.id, type='user', request=request)
+
     if user.update(**request.json):
         return jsonify(status='ok')
     else:
@@ -106,6 +116,9 @@ def update_user_attributes(user_id):
     if not user:
         raise ApiError('not found', 404)
 
+    audit_trail.send(current_app._get_current_object(), event='user-attributes-updated', message='', user=g.user,
+                     customers=g.customers, scopes=g.scopes, resource_id=user.id, type='user', request=request)
+
     if user.update_attributes(request.json['attributes']):
         return jsonify(status='ok')
     else:
@@ -124,6 +137,9 @@ def update_me_attributes():
 
     if not user:
         raise ApiError('not found', 404)
+
+    audit_trail.send(current_app._get_current_object(), event='user-me-attributes-updated', message='', user=g.user,
+                     customers=g.customers, scopes=g.scopes, resource_id=user.id, type='user', request=request)
 
     if user.update_attributes(request.json['attributes']):
         return jsonify(status='ok')
@@ -165,6 +181,9 @@ def delete_user(user_id):
 
     if not user:
         raise ApiError('not found', 404)
+
+    audit_trail.send(current_app._get_current_object(), event='user-deleted', message='', user=g.user,
+                     customers=g.customers, scopes=g.scopes, resource_id=user.id, type='user', request=request)
 
     if user.delete():
         return jsonify(status='ok')

--- a/alerta/webhooks/cloudwatch.py
+++ b/alerta/webhooks/cloudwatch.py
@@ -3,7 +3,7 @@ import json
 from datetime import datetime
 from typing import Any, Dict
 
-from flask import jsonify, request
+from flask import current_app, g, jsonify, request
 from flask_cors import cross_origin
 
 from alerta.auth.decorators import permission
@@ -11,6 +11,7 @@ from alerta.exceptions import ApiError, RejectException
 from alerta.models.alert import Alert
 from alerta.models.enums import Scope
 from alerta.utils.api import add_remote_ip, assign_customer, process_alert
+from alerta.utils.audit import audit_trail
 
 from . import webhooks
 
@@ -98,6 +99,10 @@ def cloudwatch():
         raise ApiError(str(e), 403)
     except Exception as e:
         raise ApiError(str(e), 500)
+
+    text = 'cloudwatch alert received via webhook'
+    audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
+                     customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     if alert:
         return jsonify(status='ok', id=alert.id, alert=alert.serialize), 201

--- a/alerta/webhooks/grafana.py
+++ b/alerta/webhooks/grafana.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Dict
 
-from flask import current_app, jsonify, request
+from flask import current_app, g, jsonify, request
 from flask_cors import cross_origin
 from werkzeug.datastructures import ImmutableMultiDict
 
@@ -11,6 +11,7 @@ from alerta.exceptions import ApiError, RejectException
 from alerta.models.alert import Alert
 from alerta.models.enums import Scope
 from alerta.utils.api import add_remote_ip, assign_customer, process_alert
+from alerta.utils.audit import audit_trail
 
 from . import webhooks
 
@@ -106,6 +107,11 @@ def grafana():
             alerts.append(alert)
     else:
         raise ApiError('no alerts in Grafana notification payload', 400)
+
+    for alert in alerts:
+        text = 'grafana alert received via webhook'
+        audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
+                         customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     if len(alerts) == 1:
         return jsonify(status='ok', id=alerts[0].id, alert=alerts[0].serialize), 201

--- a/alerta/webhooks/graylog.py
+++ b/alerta/webhooks/graylog.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from flask import jsonify, request
+from flask import current_app, g, jsonify, request
 from flask_cors import cross_origin
 
 from alerta.auth.decorators import permission
@@ -8,6 +8,7 @@ from alerta.exceptions import ApiError, RejectException
 from alerta.models.alert import Alert
 from alerta.models.enums import Scope
 from alerta.utils.api import add_remote_ip, assign_customer, process_alert
+from alerta.utils.audit import audit_trail
 
 from . import webhooks
 
@@ -60,6 +61,10 @@ def graylog():
         raise ApiError(str(e), 403)
     except Exception as e:
         raise ApiError(str(e), 500)
+
+    text = 'graylog alert received via webhook'
+    audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
+                     customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     if alert:
         return jsonify(status='ok', id=alert.id, alert=alert.serialize), 201

--- a/alerta/webhooks/newrelic.py
+++ b/alerta/webhooks/newrelic.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from flask import jsonify, request
+from flask import current_app, g, jsonify, request
 from flask_cors import cross_origin
 
 from alerta.auth.decorators import permission
@@ -8,6 +8,7 @@ from alerta.exceptions import ApiError, RejectException
 from alerta.models.alert import Alert
 from alerta.models.enums import Scope
 from alerta.utils.api import add_remote_ip, assign_customer, process_alert
+from alerta.utils.audit import audit_trail
 
 from . import webhooks
 
@@ -76,6 +77,10 @@ def newrelic():
         raise ApiError(str(e), 403)
     except Exception as e:
         raise ApiError(str(e), 500)
+
+    text = 'newrelic alert received via webhook'
+    audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
+                     customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     if alert:
         return jsonify(status='ok', id=alert.id, alert=alert.serialize), 201

--- a/alerta/webhooks/pingdom.py
+++ b/alerta/webhooks/pingdom.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from flask import jsonify, request
+from flask import current_app, g, jsonify, request
 from flask_cors import cross_origin
 
 from alerta.auth.decorators import permission
@@ -8,6 +8,7 @@ from alerta.exceptions import ApiError, RejectException
 from alerta.models.alert import Alert
 from alerta.models.enums import Scope
 from alerta.utils.api import add_remote_ip, assign_customer, process_alert
+from alerta.utils.audit import audit_trail
 
 from . import webhooks
 
@@ -88,6 +89,10 @@ def pingdom():
         raise ApiError(str(e), 403)
     except Exception as e:
         raise ApiError(str(e), 500)
+
+    text = 'pingdom alert received via webhook'
+    audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
+                     customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     if alert:
         return jsonify(status='ok', id=alert.id, alert=alert.serialize), 201

--- a/alerta/webhooks/riemann.py
+++ b/alerta/webhooks/riemann.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from flask import jsonify, request
+from flask import current_app, g, jsonify, request
 from flask_cors import cross_origin
 
 from alerta.auth.decorators import permission
@@ -8,6 +8,7 @@ from alerta.exceptions import ApiError, RejectException
 from alerta.models.alert import Alert
 from alerta.models.enums import Scope
 from alerta.utils.api import add_remote_ip, assign_customer, process_alert
+from alerta.utils.audit import audit_trail
 
 from . import webhooks
 
@@ -50,6 +51,10 @@ def riemann():
         raise ApiError(str(e), 403)
     except Exception as e:
         raise ApiError(str(e), 500)
+
+    text = 'riemann alert received via webhook'
+    audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
+                     customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     if alert:
         return jsonify(status='ok', id=alert.id, alert=alert.serialize), 201

--- a/alerta/webhooks/serverdensity.py
+++ b/alerta/webhooks/serverdensity.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from flask import jsonify, request
+from flask import current_app, g, jsonify, request
 from flask_cors import cross_origin
 
 from alerta.auth.decorators import permission
@@ -8,6 +8,7 @@ from alerta.exceptions import ApiError, RejectException
 from alerta.models.alert import Alert
 from alerta.models.enums import Scope
 from alerta.utils.api import add_remote_ip, assign_customer, process_alert
+from alerta.utils.audit import audit_trail
 
 from . import webhooks
 
@@ -60,6 +61,11 @@ def serverdensity():
         raise ApiError(str(e), 403)
     except Exception as e:
         raise ApiError(str(e), 500)
+
+    text = 'serverdensity alert received via webhook'
+    audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
+                     customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
+
     if alert:
         return jsonify(status='ok', id=alert.id, alert=alert.serialize), 201
     else:

--- a/alerta/webhooks/stackdriver.py
+++ b/alerta/webhooks/stackdriver.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 from typing import Any, Dict
 
-from flask import jsonify, request
+from flask import current_app, g, jsonify, request
 from flask_cors import cross_origin
 
 from alerta.auth.decorators import permission
@@ -10,6 +10,7 @@ from alerta.exceptions import ApiError, RejectException
 from alerta.models.alert import Alert
 from alerta.models.enums import Scope
 from alerta.utils.api import add_remote_ip, assign_customer, process_alert
+from alerta.utils.audit import audit_trail
 
 from . import webhooks
 
@@ -78,6 +79,10 @@ def stackdriver():
         raise ApiError(str(e), 403)
     except Exception as e:
         raise ApiError(str(e), 500)
+
+    text = 'stackdriver alert received via webhook'
+    audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
+                     customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     if alert:
         return jsonify(status='ok', id=alert.id, alert=alert.serialize), 201

--- a/alerta/webhooks/telegram.py
+++ b/alerta/webhooks/telegram.py
@@ -10,6 +10,7 @@ from alerta.auth.decorators import permission
 from alerta.models.alert import Alert
 from alerta.models.blackout import Blackout
 from alerta.models.enums import Scope
+from alerta.utils.audit import audit_trail
 
 from . import webhooks
 
@@ -94,6 +95,11 @@ def telegram():
             blackout.create()
 
         send_message_reply(alert, action, user, data)
+
+        text = 'alert updated via telegram webhook'
+        audit_trail.send(current_app._get_current_object(), event='webhook-updated', message=text, user=g.user,
+                         customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
+
         return jsonify(status='ok')
     else:
         return jsonify(status='ok', message='no callback_query in Telegram message')

--- a/mypy.ini
+++ b/mypy.ini
@@ -35,3 +35,6 @@ ignore_missing_imports = True
 
 [mypy-ldap.*]
 ignore_missing_imports = True
+
+[mypy-blinker.*]
+ignore_missing_imports = True


### PR DESCRIPTION
Add audit trail for alert mutations. This is an alternative approach to #735 

Every audit event will have an audit `id`, `@timestamp`, `event`, `message`, `user`, `resource`, `request` and `extra` elements. `extra` will include relevant data depending on the type of event. eg. for tag/untag it will include the list of tags.

**Example - Action (ack)**
```json
{
  "id": "128afb8e-1ac5-4030-9d2a-277b640bed6e",
  "@timestamp": "2018-11-10T11:00:56.429Z",
  "event": "alert-actioned",
  "message": "ack by nsatterl",
  "user": {
    "id": "admin@alerta.io",
    "customers": [],
    "scopes": [
      "admin",
      "read",
      "write"
    ]
  },
  "resource": {
    "id": "3a23a7b0-6ede-4b30-9e60-493aaebfc325",
    "type": "alert"
  },
  "request": {
    "endpoint": "api.action_alert",
    "method": "PUT",
    "url": "http://localhost:8080/alert/3a23a7b0-6ede-4b30-9e60-493aaebfc325/action",
    "args": {},
    "data": "{\"action\": \"ack\", \"text\": \"ack by nsatterl\", \"timeout\": null}",
    "ipAddress": "127.0.0.1"
  },
  "extra": {}
}
```
**Example - Login (GitLab)**
```json
{
  "id": "483cb9c9-d4e1-488c-aa5e-4ee87485f7b5",
  "@timestamp": "2018-11-10T11:05:48.682Z",
  "event": "gitlab-login",
  "message": "user login via GitLab",
  "user": {
    "id": "satterly",
    "customers": [],
    "scopes": [
      "admin",
      "read",
      "write"
    ]
  },
  "resource": {
    "id": "1565012",
    "type": "gitlab"
  },
  "request": {
    "endpoint": "auth.gitlab",
    "method": "POST",
    "url": "http://localhost:8080/auth/gitlab",
    "args": {},
    "data": "{\"code\": \"8d19c1e807a80c85fc12e15cb033561f5da87e12c8311a4b1752a537cd666136\", \"clientId\": \"765904e9909fc9cc5c448a887849029d999cc2e400e097221bf910be39a16678\", \"redirectUri\": \"http://127.0.0.1:9004\"}",
    "ipAddress": "127.0.0.1"
  },
  "extra": {}
}
```
Audit events can be logged locally to the standard application log (which could also help with general debugging) or forwarded to a HTTP endpoint using a POST.

**Note:** The impact on performance of sending an additional HTTP POST during alert processing is currently unknown and should be reviewed if it causes problems (ie. moved to an async celery task). The HTTP POST is set to aggressively time out at 2 seconds by default.

References
https://app.logz.io/#/dashboard/data-sources/JSON
https://www.loggly.com/docs/automated-parsing/#json

/cc @frankd4github