### PR TITLE
Split audit signals into admin, write and auth categories

### DIFF
--- a/alerta/auth/basic_ldap.py
+++ b/alerta/auth/basic_ldap.py
@@ -7,7 +7,7 @@ from alerta.auth.utils import create_token, get_customers
 from alerta.exceptions import ApiError
 from alerta.models.permission import Permission
 from alerta.models.user import User
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import auth_audit_trail
 
 from . import auth
 
@@ -55,9 +55,9 @@ def login():
     customers = get_customers(user.email, groups=[user.domain])
     user.update_last_login()
 
-    audit_trail.send(current_app._get_current_object(), event='basic-ldap-login', message='user login via LDAP',
-                     user=user.email, customers=customers, scopes=Permission.lookup(login, groups=user.roles),
-                     resource_id=user.id, type='user', request=request)
+    auth_audit_trail.send(current_app._get_current_object(), event='basic-ldap-login', message='user login via LDAP',
+                          user=user.email, customers=customers, scopes=Permission.lookup(login, groups=user.roles),
+                          resource_id=user.id, type='user', request=request)
 
     # Generate token
     token = create_token(user_id=user.id, name=user.name, login=user.email, provider='basic_ldap',

--- a/alerta/auth/github.py
+++ b/alerta/auth/github.py
@@ -6,7 +6,7 @@ from flask_cors import cross_origin
 from alerta.auth.utils import create_token, get_customers, not_authorized
 from alerta.exceptions import ApiError
 from alerta.models.permission import Permission
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import auth_audit_trail
 
 from . import auth
 
@@ -50,9 +50,9 @@ def github():
 
     customers = get_customers(login, organizations)
 
-    audit_trail.send(current_app._get_current_object(), event='github-login', message='user login via GitHub',
-                     user=login, customers=customers, scopes=Permission.lookup(login, groups=organizations),
-                     resource_id=profile['id'], type='github', request=request)
+    auth_audit_trail.send(current_app._get_current_object(), event='github-login', message='user login via GitHub',
+                          user=login, customers=customers, scopes=Permission.lookup(login, groups=organizations),
+                          resource_id=profile['id'], type='github', request=request)
 
     token = create_token(user_id=profile['id'], name=profile.get('name', '@' + login), login=login, provider='github',
                          customers=customers, orgs=organizations, email=profile.get('email', None),

--- a/alerta/auth/gitlab.py
+++ b/alerta/auth/gitlab.py
@@ -6,7 +6,7 @@ from flask_cors import cross_origin
 from alerta.auth.utils import create_token, get_customers, not_authorized
 from alerta.exceptions import ApiError
 from alerta.models.permission import Permission
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import auth_audit_trail
 
 from . import auth
 
@@ -63,9 +63,9 @@ def gitlab():
 
     customers = get_customers(login, groups)
 
-    audit_trail.send(current_app._get_current_object(), event='gitlab-login', message='user login via GitLab',
-                     user=login, customers=customers, scopes=Permission.lookup(login, groups=groups),
-                     resource_id=user_id, type='gitlab', request=request)
+    auth_audit_trail.send(current_app._get_current_object(), event='gitlab-login', message='user login via GitLab',
+                          user=login, customers=customers, scopes=Permission.lookup(login, groups=groups),
+                          resource_id=user_id, type='gitlab', request=request)
 
     token = create_token(user_id=user_id, name=profile.get('name', '@' + login), login=login, provider='gitlab',
                          customers=customers, groups=groups, email=profile.get('email', None), email_verified=email_verified)

--- a/alerta/auth/google.py
+++ b/alerta/auth/google.py
@@ -7,7 +7,7 @@ from alerta.auth.utils import create_token, get_customers, not_authorized
 from alerta.exceptions import ApiError
 from alerta.models.permission import Permission
 from alerta.models.token import Jwt
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import auth_audit_trail
 
 from . import auth
 
@@ -51,10 +51,10 @@ def google():
     customers = get_customers(id_token.email, groups=[domain])
     name = profile.get('name', id_token.email.split('@')[0])
 
-    audit_trail.send(current_app._get_current_object(), event='google-login', message='user login via Google',
-                     user=id_token.email, customers=customers,
-                     scopes=Permission.lookup(id_token.email, groups=[domain]),
-                     resource_id=id_token.subject, type='google', request=request)
+    auth_audit_trail.send(current_app._get_current_object(), event='google-login', message='user login via Google',
+                          user=id_token.email, customers=customers,
+                          scopes=Permission.lookup(id_token.email, groups=[domain]),
+                          resource_id=id_token.subject, type='google', request=request)
 
     token = create_token(user_id=id_token.subject, name=name, login=id_token.email, provider='google',
                          customers=customers, orgs=[domain], email=id_token.email, email_verified=id_token.email_verified)

--- a/alerta/auth/keycloak.py
+++ b/alerta/auth/keycloak.py
@@ -6,7 +6,7 @@ from flask_cors import cross_origin
 from alerta.auth.utils import create_token, get_customers, not_authorized
 from alerta.exceptions import ApiError
 from alerta.models.permission import Permission
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import auth_audit_trail
 
 from . import auth
 
@@ -48,9 +48,9 @@ def keycloak():
 
     customers = get_customers(login, groups=roles)
 
-    audit_trail.send(current_app._get_current_object(), event='keycloak-login', message='user login via Keycloak',
-                     user=login, customers=customers, scopes=Permission.lookup(login, groups=roles),
-                     resource_id=profile['sub'], type='keycloak', request=request)
+    auth_audit_trail.send(current_app._get_current_object(), event='keycloak-login', message='user login via Keycloak',
+                          user=login, customers=customers, scopes=Permission.lookup(login, groups=roles),
+                          resource_id=profile['sub'], type='keycloak', request=request)
 
     token = create_token(user_id=profile['sub'], name=profile['name'], login=login, provider='keycloak',
                          customers=customers, roles=roles)

--- a/alerta/auth/pingfederate.py
+++ b/alerta/auth/pingfederate.py
@@ -6,7 +6,7 @@ from flask_cors import cross_origin
 
 from alerta.auth.utils import create_token, get_customers
 from alerta.models.permission import Permission
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import auth_audit_trail
 
 from . import auth
 
@@ -42,9 +42,9 @@ def pingfederate():
     email = decoded[current_app.config['PINGFEDERATE_OPENID_PAYLOAD_EMAIL']]
     customers = get_customers(login, current_app.config['PINGFEDERATE_OPENID_PAYLOAD_GROUP'])
 
-    audit_trail.send(current_app._get_current_object(), event='pingfederate-login', message='user login via PingFederate',
-                     user=email, customers=customers, scopes=Permission.lookup(login, groups=[]),
-                     resource_id=login, type='pingfederate', request=request)
+    auth_audit_trail.send(current_app._get_current_object(), event='pingfederate-login', message='user login via PingFederate',
+                          user=email, customers=customers, scopes=Permission.lookup(login, groups=[]),
+                          resource_id=login, type='pingfederate', request=request)
 
     token = create_token(user_id=login, name=email, login=email, provider='openid', customers=customers)
     return jsonify(token=token.tokenize)

--- a/alerta/auth/saml2.py
+++ b/alerta/auth/saml2.py
@@ -7,7 +7,7 @@ from flask_cors import cross_origin
 from alerta.auth.utils import (create_token, deepmerge, get_customers,
                                not_authorized)
 from alerta.models.permission import Permission
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import auth_audit_trail
 from alerta.utils.response import absolute_url
 
 from . import auth
@@ -104,9 +104,9 @@ def saml_response_from_idp():
 
     customers = get_customers(email, groups=[domain])
 
-    audit_trail.send(current_app._get_current_object(), event='saml2-login', message='user login via SAML2',
-                     user=email, customers=customers, scopes=Permission.lookup(email, groups=groups),
-                     resource_id=email, type='saml2', request=request)
+    auth_audit_trail.send(current_app._get_current_object(), event='saml2-login', message='user login via SAML2',
+                          user=email, customers=customers, scopes=Permission.lookup(email, groups=groups),
+                          resource_id=email, type='saml2', request=request)
 
     token = create_token(user_id=email, name=name, login=email, provider='saml2', customers=customers, groups=groups)
     return _make_response({'status': 'ok', 'token': token.tokenize}, 200)

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -49,6 +49,7 @@ CELERY_ACCEPT_CONTENT = ['customjson']
 CELERY_TASK_SERIALIZER = 'customjson'
 CELERY_RESULT_SERIALIZER = 'customjson'
 
+AUDIT_TRAIL = ['admin']  # possible categories are 'admin', 'write', and 'auth'
 AUDIT_LOG = None  # set to True to log to application logger
 AUDIT_URL = None  # send audit log events via webhook URL
 

--- a/alerta/views/alerts.py
+++ b/alerta/views/alerts.py
@@ -14,7 +14,7 @@ from alerta.models.metrics import Timer, timer
 from alerta.models.switch import Switch
 from alerta.utils.api import (add_remote_ip, assign_customer, process_action,
                               process_alert, process_status)
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import write_audit_trail
 from alerta.utils.paging import Page
 from alerta.utils.response import jsonp
 
@@ -56,8 +56,8 @@ def receive():
     except Exception as e:
         raise ApiError(str(e), 500)
 
-    audit_trail.send(current_app._get_current_object(), event='alert-received', message=alert.text, user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
+    write_audit_trail.send(current_app._get_current_object(), event='alert-received', message=alert.text, user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     if alert:
         return jsonify(status='ok', id=alert.id, alert=alert.serialize), 201
@@ -108,8 +108,8 @@ def set_status(alert_id):
     except Exception as e:
         raise ApiError(str(e), 500)
 
-    audit_trail.send(current_app._get_current_object(), event='alert-status-changed', message=text, user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
+    write_audit_trail.send(current_app._get_current_object(), event='alert-status-changed', message=text, user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
     if alert:
         return jsonify(status='ok')
     else:
@@ -156,8 +156,8 @@ def action_alert(alert_id):
         except Exception as e:
             raise ApiError(str(e), 500)
 
-    audit_trail.send(current_app._get_current_object(), event='alert-actioned', message=text, user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
+    write_audit_trail.send(current_app._get_current_object(), event='alert-actioned', message=text, user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     if alert:
         return jsonify(status='ok')
@@ -183,8 +183,8 @@ def tag_alert(alert_id):
     if not alert:
         raise ApiError('not found', 404)
 
-    audit_trail.send(current_app._get_current_object(), event='alert-tagged', message='', user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
+    write_audit_trail.send(current_app._get_current_object(), event='alert-tagged', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     if alert.tag(tags):
         return jsonify(status='ok')
@@ -210,8 +210,8 @@ def untag_alert(alert_id):
     if not alert:
         raise ApiError('not found', 404)
 
-    audit_trail.send(current_app._get_current_object(), event='alert-untagged', message='', user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
+    write_audit_trail.send(current_app._get_current_object(), event='alert-untagged', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     if alert.untag(tags):
         return jsonify(status='ok')
@@ -237,8 +237,8 @@ def update_attributes(alert_id):
     if not alert:
         raise ApiError('not found', 404)
 
-    audit_trail.send(current_app._get_current_object(), event='alert-attributes-updated', message='', user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
+    write_audit_trail.send(current_app._get_current_object(), event='alert-attributes-updated', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     if alert.update_attributes(attributes):
         return jsonify(status='ok')
@@ -259,8 +259,8 @@ def delete_alert(alert_id):
     if not alert:
         raise ApiError('not found', 404)
 
-    audit_trail.send(current_app._get_current_object(), event='alert-deleted', message='', user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
+    write_audit_trail.send(current_app._get_current_object(), event='alert-deleted', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     if alert.delete():
         return jsonify(status='ok')

--- a/alerta/views/blackouts.py
+++ b/alerta/views/blackouts.py
@@ -8,7 +8,7 @@ from alerta.exceptions import ApiError
 from alerta.models.blackout import Blackout
 from alerta.models.enums import Scope
 from alerta.utils.api import assign_customer
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import write_audit_trail
 from alerta.utils.response import absolute_url, jsonp
 
 from . import api
@@ -36,8 +36,8 @@ def create_blackout():
     except Exception as e:
         raise ApiError(str(e), 500)
 
-    audit_trail.send(current_app._get_current_object(), event='blackout-created', message='', user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=blackout.id, type='blackout', request=request)
+    write_audit_trail.send(current_app._get_current_object(), event='blackout-created', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=blackout.id, type='blackout', request=request)
 
     if blackout:
         return jsonify(status='ok', id=blackout.id, blackout=blackout.serialize), 201, {'Location': absolute_url('/blackout/' + blackout.id)}
@@ -79,8 +79,8 @@ def delete_blackout(blackout_id):
     if not blackout:
         raise ApiError('not found', 404)
 
-    audit_trail.send(current_app._get_current_object(), event='blackout-deleted', message='', user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=blackout.id, type='blackout', request=request)
+    write_audit_trail.send(current_app._get_current_object(), event='blackout-deleted', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=blackout.id, type='blackout', request=request)
 
     if blackout.delete():
         return jsonify(status='ok')

--- a/alerta/views/customers.py
+++ b/alerta/views/customers.py
@@ -7,7 +7,7 @@ from alerta.auth.decorators import permission
 from alerta.exceptions import ApiError
 from alerta.models.customer import Customer
 from alerta.models.enums import Scope
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import admin_audit_trail
 from alerta.utils.response import jsonp
 
 from . import api
@@ -28,8 +28,8 @@ def create_customer():
     except Exception as e:
         raise ApiError(str(e), 500)
 
-    audit_trail.send(current_app._get_current_object(), event='customer-created', message='', user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=customer.id, type='customer', request=request)
+    admin_audit_trail.send(current_app._get_current_object(), event='customer-created', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=customer.id, type='customer', request=request)
 
     if customer:
         return jsonify(status='ok', id=customer.id, customer=customer.serialize), 201
@@ -70,8 +70,8 @@ def delete_customer(customer_id):
     if not customer:
         raise ApiError('not found', 404)
 
-    audit_trail.send(current_app._get_current_object(), event='customer-deleted', message='', user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=customer.id, type='customer', request=request)
+    admin_audit_trail.send(current_app._get_current_object(), event='customer-deleted', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=customer.id, type='customer', request=request)
 
     if customer.delete():
         return jsonify(status='ok')

--- a/alerta/views/heartbeats.py
+++ b/alerta/views/heartbeats.py
@@ -8,7 +8,7 @@ from alerta.exceptions import ApiError
 from alerta.models.enums import Scope
 from alerta.models.heartbeat import Heartbeat
 from alerta.utils.api import assign_customer
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import write_audit_trail
 from alerta.utils.response import jsonp
 
 from . import api
@@ -31,8 +31,8 @@ def create_heartbeat():
     except Exception as e:
         raise ApiError(str(e), 500)
 
-    audit_trail.send(current_app._get_current_object(), event='heartbeat-created', message='', user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=heartbeat.id, type='heartbeat', request=request)
+    write_audit_trail.send(current_app._get_current_object(), event='heartbeat-created', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=heartbeat.id, type='heartbeat', request=request)
 
     if heartbeat:
         return jsonify(status='ok', id=heartbeat.id, heartbeat=heartbeat.serialize), 201
@@ -88,8 +88,8 @@ def delete_heartbeat(heartbeat_id):
     if not heartbeat:
         raise ApiError('not found', 404)
 
-    audit_trail.send(current_app._get_current_object(), event='heartbeat-deleted', message='', user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=heartbeat.id, type='heartbeat', request=request)
+    write_audit_trail.send(current_app._get_current_object(), event='heartbeat-deleted', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=heartbeat.id, type='heartbeat', request=request)
 
     if heartbeat.delete():
         return jsonify(status='ok')

--- a/alerta/views/keys.py
+++ b/alerta/views/keys.py
@@ -7,7 +7,7 @@ from alerta.models.enums import Scope
 from alerta.models.key import ApiKey
 from alerta.models.permission import Permission
 from alerta.utils.api import assign_customer
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import admin_audit_trail, write_audit_trail
 from alerta.utils.response import jsonp
 
 from . import api
@@ -43,8 +43,8 @@ def create_key():
     except Exception as e:
         raise ApiError(str(e), 500)
 
-    audit_trail.send(current_app._get_current_object(), event='apikey-created', message='', user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=key.id, type='apikey', request=request)
+    write_audit_trail.send(current_app._get_current_object(), event='apikey-created', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=key.id, type='apikey', request=request)
 
     if key:
         return jsonify(status='ok', key=key.key, data=key.serialize), 201
@@ -91,8 +91,8 @@ def delete_key(key):
     if not key:
         raise ApiError('not found', 404)
 
-    audit_trail.send(current_app._get_current_object(), event='apikey-deleted', message='', user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=key.id, type='apikey', request=request)
+    admin_audit_trail.send(current_app._get_current_object(), event='apikey-deleted', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=key.id, type='apikey', request=request)
 
     if key.delete():
         return jsonify(status='ok')

--- a/alerta/views/permissions.py
+++ b/alerta/views/permissions.py
@@ -6,7 +6,7 @@ from alerta.auth.decorators import permission
 from alerta.exceptions import ApiError
 from alerta.models.enums import Scope
 from alerta.models.permission import Permission
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import admin_audit_trail
 from alerta.utils.response import jsonp
 
 from . import api
@@ -32,8 +32,8 @@ def create_perm():
     except Exception as e:
         raise ApiError(str(e), 500)
 
-    audit_trail.send(current_app._get_current_object(), event='permission-created', message='', user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=perm.id, type='permission', request=request)
+    admin_audit_trail.send(current_app._get_current_object(), event='permission-created', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=perm.id, type='permission', request=request)
 
     if perm:
         return jsonify(status='ok', id=perm.id, permission=perm.serialize), 201
@@ -73,8 +73,8 @@ def delete_perm(perm_id):
     if not perm:
         raise ApiError('not found', 404)
 
-    audit_trail.send(current_app._get_current_object(), event='permission-deleted', message='', user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=perm.id, type='permission', request=request)
+    admin_audit_trail.send(current_app._get_current_object(), event='permission-deleted', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=perm.id, type='permission', request=request)
 
     if perm.delete():
         return jsonify(status='ok')

--- a/alerta/views/users.py
+++ b/alerta/views/users.py
@@ -7,7 +7,7 @@ from alerta.auth.utils import not_authorized
 from alerta.exceptions import ApiError
 from alerta.models.enums import Scope
 from alerta.models.user import User
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import admin_audit_trail, write_audit_trail
 from alerta.utils.response import jsonp
 
 from . import api
@@ -39,8 +39,8 @@ def create_user():
     if current_app.config['EMAIL_VERIFICATION'] and not user.email_verified:
         user.send_confirmation()
 
-    audit_trail.send(current_app._get_current_object(), event='user-created', message='', user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=user.id, type='user', request=request)
+    admin_audit_trail.send(current_app._get_current_object(), event='user-created', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=user.id, type='user', request=request)
 
     if user:
         return jsonify(status='ok', id=user.id, user=user.serialize), 201
@@ -64,8 +64,8 @@ def update_user(user_id):
     if 'email' in request.json and User.find_by_email(request.json['email']):
         raise ApiError('user with email already exists', 409)
 
-    audit_trail.send(current_app._get_current_object(), event='user-updated', message='', user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=user.id, type='user', request=request)
+    admin_audit_trail.send(current_app._get_current_object(), event='user-updated', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=user.id, type='user', request=request)
 
     if user.update(**request.json):
         return jsonify(status='ok')
@@ -94,8 +94,8 @@ def update_me():
     if 'email' in request.json and User.find_by_email(request.json['email']):
         raise ApiError('user with email already exists', 409)
 
-    audit_trail.send(current_app._get_current_object(), event='user-me-updated', message='', user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=user.id, type='user', request=request)
+    write_audit_trail.send(current_app._get_current_object(), event='user-me-updated', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=user.id, type='user', request=request)
 
     if user.update(**request.json):
         return jsonify(status='ok')
@@ -116,8 +116,8 @@ def update_user_attributes(user_id):
     if not user:
         raise ApiError('not found', 404)
 
-    audit_trail.send(current_app._get_current_object(), event='user-attributes-updated', message='', user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=user.id, type='user', request=request)
+    admin_audit_trail.send(current_app._get_current_object(), event='user-attributes-updated', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=user.id, type='user', request=request)
 
     if user.update_attributes(request.json['attributes']):
         return jsonify(status='ok')
@@ -138,8 +138,8 @@ def update_me_attributes():
     if not user:
         raise ApiError('not found', 404)
 
-    audit_trail.send(current_app._get_current_object(), event='user-me-attributes-updated', message='', user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=user.id, type='user', request=request)
+    write_audit_trail.send(current_app._get_current_object(), event='user-me-attributes-updated', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=user.id, type='user', request=request)
 
     if user.update_attributes(request.json['attributes']):
         return jsonify(status='ok')
@@ -182,8 +182,8 @@ def delete_user(user_id):
     if not user:
         raise ApiError('not found', 404)
 
-    audit_trail.send(current_app._get_current_object(), event='user-deleted', message='', user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=user.id, type='user', request=request)
+    admin_audit_trail.send(current_app._get_current_object(), event='user-deleted', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=user.id, type='user', request=request)
 
     if user.delete():
         return jsonify(status='ok')

--- a/alerta/webhooks/cloudwatch.py
+++ b/alerta/webhooks/cloudwatch.py
@@ -11,7 +11,7 @@ from alerta.exceptions import ApiError, RejectException
 from alerta.models.alert import Alert
 from alerta.models.enums import Scope
 from alerta.utils.api import add_remote_ip, assign_customer, process_alert
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import write_audit_trail
 
 from . import webhooks
 
@@ -101,8 +101,8 @@ def cloudwatch():
         raise ApiError(str(e), 500)
 
     text = 'cloudwatch alert received via webhook'
-    audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
+    write_audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     if alert:
         return jsonify(status='ok', id=alert.id, alert=alert.serialize), 201

--- a/alerta/webhooks/custom.py
+++ b/alerta/webhooks/custom.py
@@ -7,7 +7,7 @@ from alerta.auth.decorators import permission
 from alerta.exceptions import ApiError, RejectException
 from alerta.models.enums import Scope
 from alerta.utils.api import add_remote_ip, assign_customer, process_alert
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import write_audit_trail
 
 from . import webhooks
 
@@ -37,8 +37,8 @@ def custom(webhook):
         raise ApiError(str(e), 500)
 
     text = '{} alert received via custom webhook'.format(webhook)
-    audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
+    write_audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     if alert:
         return jsonify(status='ok', id=alert.id, alert=alert.serialize), 201

--- a/alerta/webhooks/grafana.py
+++ b/alerta/webhooks/grafana.py
@@ -11,7 +11,7 @@ from alerta.exceptions import ApiError, RejectException
 from alerta.models.alert import Alert
 from alerta.models.enums import Scope
 from alerta.utils.api import add_remote_ip, assign_customer, process_alert
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import write_audit_trail
 
 from . import webhooks
 
@@ -110,8 +110,8 @@ def grafana():
 
     for alert in alerts:
         text = 'grafana alert received via webhook'
-        audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
-                         customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
+        write_audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
+                               customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     if len(alerts) == 1:
         return jsonify(status='ok', id=alerts[0].id, alert=alerts[0].serialize), 201

--- a/alerta/webhooks/graylog.py
+++ b/alerta/webhooks/graylog.py
@@ -8,7 +8,7 @@ from alerta.exceptions import ApiError, RejectException
 from alerta.models.alert import Alert
 from alerta.models.enums import Scope
 from alerta.utils.api import add_remote_ip, assign_customer, process_alert
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import write_audit_trail
 
 from . import webhooks
 
@@ -63,8 +63,8 @@ def graylog():
         raise ApiError(str(e), 500)
 
     text = 'graylog alert received via webhook'
-    audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
+    write_audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     if alert:
         return jsonify(status='ok', id=alert.id, alert=alert.serialize), 201

--- a/alerta/webhooks/newrelic.py
+++ b/alerta/webhooks/newrelic.py
@@ -8,7 +8,7 @@ from alerta.exceptions import ApiError, RejectException
 from alerta.models.alert import Alert
 from alerta.models.enums import Scope
 from alerta.utils.api import add_remote_ip, assign_customer, process_alert
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import write_audit_trail
 
 from . import webhooks
 
@@ -79,8 +79,8 @@ def newrelic():
         raise ApiError(str(e), 500)
 
     text = 'newrelic alert received via webhook'
-    audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
+    write_audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     if alert:
         return jsonify(status='ok', id=alert.id, alert=alert.serialize), 201

--- a/alerta/webhooks/pagerduty.py
+++ b/alerta/webhooks/pagerduty.py
@@ -7,7 +7,7 @@ from alerta.auth.decorators import permission
 from alerta.exceptions import ApiError
 from alerta.models.alert import Alert
 from alerta.models.enums import Scope
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import write_audit_trail
 
 from . import webhooks
 
@@ -94,9 +94,9 @@ def pagerduty():
                 raise ApiError(str(e), 500)
 
             text = 'alert updated via pagerduty webhook'
-            audit_trail.send(current_app._get_current_object(), event='webhook-updated', message=text, user=g.user,
-                             customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert',
-                             request=request)
+            write_audit_trail.send(current_app._get_current_object(), event='webhook-updated', message=text, user=g.user,
+                                   customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert',
+                                   request=request)
     else:
         raise ApiError('no messages in PagerDuty data payload', 400)
 

--- a/alerta/webhooks/pingdom.py
+++ b/alerta/webhooks/pingdom.py
@@ -8,7 +8,7 @@ from alerta.exceptions import ApiError, RejectException
 from alerta.models.alert import Alert
 from alerta.models.enums import Scope
 from alerta.utils.api import add_remote_ip, assign_customer, process_alert
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import write_audit_trail
 
 from . import webhooks
 
@@ -91,8 +91,8 @@ def pingdom():
         raise ApiError(str(e), 500)
 
     text = 'pingdom alert received via webhook'
-    audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
+    write_audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     if alert:
         return jsonify(status='ok', id=alert.id, alert=alert.serialize), 201

--- a/alerta/webhooks/prometheus.py
+++ b/alerta/webhooks/prometheus.py
@@ -12,7 +12,7 @@ from alerta.exceptions import ApiError, RejectException
 from alerta.models.alert import Alert
 from alerta.models.enums import Scope
 from alerta.utils.api import add_remote_ip, assign_customer, process_alert
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import write_audit_trail
 
 from . import webhooks
 
@@ -134,8 +134,8 @@ def prometheus():
 
     for alert in alerts:
         text = 'prometheus alert received via webhook'
-        audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
-                         customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
+        write_audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
+                               customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     if len(alerts) == 1:
         return jsonify(status='ok', id=alerts[0].id, alert=alerts[0].serialize), 201

--- a/alerta/webhooks/riemann.py
+++ b/alerta/webhooks/riemann.py
@@ -8,7 +8,7 @@ from alerta.exceptions import ApiError, RejectException
 from alerta.models.alert import Alert
 from alerta.models.enums import Scope
 from alerta.utils.api import add_remote_ip, assign_customer, process_alert
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import write_audit_trail
 
 from . import webhooks
 
@@ -53,8 +53,8 @@ def riemann():
         raise ApiError(str(e), 500)
 
     text = 'riemann alert received via webhook'
-    audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
+    write_audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     if alert:
         return jsonify(status='ok', id=alert.id, alert=alert.serialize), 201

--- a/alerta/webhooks/serverdensity.py
+++ b/alerta/webhooks/serverdensity.py
@@ -8,7 +8,7 @@ from alerta.exceptions import ApiError, RejectException
 from alerta.models.alert import Alert
 from alerta.models.enums import Scope
 from alerta.utils.api import add_remote_ip, assign_customer, process_alert
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import write_audit_trail
 
 from . import webhooks
 
@@ -63,8 +63,8 @@ def serverdensity():
         raise ApiError(str(e), 500)
 
     text = 'serverdensity alert received via webhook'
-    audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
+    write_audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     if alert:
         return jsonify(status='ok', id=alert.id, alert=alert.serialize), 201

--- a/alerta/webhooks/slack.py
+++ b/alerta/webhooks/slack.py
@@ -10,7 +10,7 @@ from alerta.auth.decorators import permission
 from alerta.exceptions import ApiError
 from alerta.models.alert import Alert
 from alerta.models.enums import Scope
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import write_audit_trail
 from alerta.utils.response import absolute_url
 
 from . import webhooks
@@ -94,8 +94,8 @@ def slack():
         raise ApiError('Unsupported #slack action', 400)
 
     text = 'alert updated via slack webhook'
-    audit_trail.send(current_app._get_current_object(), event='webhook-updated', message=text, user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
+    write_audit_trail.send(current_app._get_current_object(), event='webhook-updated', message=text, user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     response = build_slack_response(alert, action, user, request.form)
     return jsonify(**response), 201

--- a/alerta/webhooks/stackdriver.py
+++ b/alerta/webhooks/stackdriver.py
@@ -10,7 +10,7 @@ from alerta.exceptions import ApiError, RejectException
 from alerta.models.alert import Alert
 from alerta.models.enums import Scope
 from alerta.utils.api import add_remote_ip, assign_customer, process_alert
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import write_audit_trail
 
 from . import webhooks
 
@@ -81,8 +81,8 @@ def stackdriver():
         raise ApiError(str(e), 500)
 
     text = 'stackdriver alert received via webhook'
-    audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
-                     customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
+    write_audit_trail.send(current_app._get_current_object(), event='webhook-received', message=text, user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
     if alert:
         return jsonify(status='ok', id=alert.id, alert=alert.serialize), 201

--- a/alerta/webhooks/telegram.py
+++ b/alerta/webhooks/telegram.py
@@ -10,7 +10,7 @@ from alerta.auth.decorators import permission
 from alerta.models.alert import Alert
 from alerta.models.blackout import Blackout
 from alerta.models.enums import Scope
-from alerta.utils.audit import audit_trail
+from alerta.utils.audit import write_audit_trail
 
 from . import webhooks
 
@@ -97,8 +97,8 @@ def telegram():
         send_message_reply(alert, action, user, data)
 
         text = 'alert updated via telegram webhook'
-        audit_trail.send(current_app._get_current_object(), event='webhook-updated', message=text, user=g.user,
-                         customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
+        write_audit_trail.send(current_app._get_current_object(), event='webhook-updated', message=text, user=g.user,
+                               customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert', request=request)
 
         return jsonify(status='ok')
     else:


### PR DESCRIPTION
Valid audit trail categories are ...
```
AUDIT_TRAIL = ['admin', 'write', 'auth']
```
**Note: Only 'admin' is enabled by default if/when audit logging is enabled.**

**Example**
```json
{
  "id": "c87210da-3cfb-4cbd-b8ec-4fe9ed39aeef",
  "@timestamp": "2018-11-10T21:36:23.946Z",
  "event": "apikey-deleted",
  "category": "admin",
  "message": "",
  "user": {
    "id": "satterly",
    "customers": [],
    "scopes": [
      "admin",
      "read",
      "write"
    ]
  },
  "resource": {
    "id": "dc0b5a62-015b-4ba3-965e-012ca2e4db9b",
    "type": "apikey"
  },
  "request": {
    "endpoint": "api.delete_key",
    "method": "DELETE",
    "url": "http://localhost:8080/key/dc0b5a62-015b-4ba3-965e-012ca2e4db9b",
    "args": {},
    "data": "",
    "ipAddress": "127.0.0.1"
  },
  "extra": {}
}
```

References

<img width="711" alt="screenshot 2018-11-10 at 22 39 29" src="https://user-images.githubusercontent.com/615057/48306468-a2addd00-e539-11e8-9a58-da08273cad53.png">

https://cloud.google.com/resource-manager/docs/audit-logging