### PR TITLE
Add query filter for users and perms

### DIFF
--- a/alerta/database/backends/postgres/utils.py
+++ b/alerta/database/backends/postgres/utils.py
@@ -104,7 +104,7 @@ class QueryBuilderImpl(QueryBuilder):
             if field in EXCLUDE_QUERY:
                 continue
             value = params.getlist(field)
-            if field in ['service', 'tags']:
+            if field in ['service', 'tags', 'roles', 'scopes']:
                 query.append('AND {0} && %({0})s'.format(field))
                 qvars[field] = value
             elif field.startswith('attributes.'):

--- a/alerta/views/users.py
+++ b/alerta/views/users.py
@@ -155,6 +155,17 @@ def search_users():
     query = qb.from_params(request.args)
     users = User.find_all(query)
 
+    # add admins defined in server config
+    if 'admin' in request.args.getlist('roles'):
+        for admin in set(current_app.config['ADMIN_USERS']):
+            user = User.find_by_email(admin)
+            if user:
+                users.append(user)
+
+    # remove admins whose default role is 'user'
+    if 'admin' not in request.args.getlist('roles'):
+        users = [u for u in users if 'admin' not in u.roles]
+
     if users:
         return jsonify(
             status='ok',


### PR DESCRIPTION
"Flat" RBAC requires ...

  * user list to be filtered by role; and
  * perms list to be filtered by scope

.. which will enable admins to answer...

  * which users have been assigned a specific role; and
  * which roles have been assigned a specific permission (scope)

**Example - Which roles have the "write" scope?**
```
http://api.local.alerta.io:8080/perms?scopes=write
```
```json
{
  "permissions": [
    {
      "href": "http://api.local.alerta.io:8080/perm/18516f71-0309-44b2-bc53-166287e2c123",
      "id": "18516f71-0309-44b2-bc53-166287e2c123",
      "match": "read-write",
      "scopes": [
        "write"
      ]
    },
    {
      "href": "http://api.local.alerta.io:8080/perm/815eac5f-c6c8-4db5-b36c-26d76160b476",
      "id": "815eac5f-c6c8-4db5-b36c-26d76160b476",
      "match": "user",
      "scopes": [
        "read",
        "write"
      ]
    }
  ],
  "status": "ok",
  "total": 2
}
```
