### PR TITLE
Trigger status change hook on alert status changes

### DIFF
--- a/alerta/app.py
+++ b/alerta/app.py
@@ -11,12 +11,14 @@ from alerta.exceptions import ExceptionHandlers
 from alerta.models.alarms import AlarmModel
 from alerta.utils.audit import AuditTrail
 from alerta.utils.config import Config
+from alerta.utils.hooks import HookTrigger
 from alerta.utils.key import ApiKeyHelper
 from alerta.utils.mailer import Mailer
 from alerta.utils.plugin import Plugins
 from alerta.utils.webhook import CustomWebhooks
 
 config = Config()
+hooks = HookTrigger()
 audit = AuditTrail()
 alarm_model = AlarmModel()
 
@@ -42,6 +44,7 @@ def create_app(config_override: Dict[str, Any]=None, environment: str=None) -> F
     if app.config['USE_PROXYFIX']:
         app.wsgi_app = ProxyFix(app.wsgi_app)
 
+    hooks.init_app(app)
     audit.init_app(app)
     alarm_model.init_app(app)
 

--- a/alerta/database/backends/mongodb/base.py
+++ b/alerta/database/backends/mongodb/base.py
@@ -332,7 +332,7 @@ class Backend(Database):
             '$addToSet': {'tags': {'$each': tags}},
             '$push': {
                 'history': {
-                    '$each': [history.serialize],
+                    '$each': [h.serialize for h in history],
                     '$slice': -abs(current_app.config['HISTORY_LIMIT'])
                 }
             }

--- a/alerta/utils/hooks.py
+++ b/alerta/utils/hooks.py
@@ -1,0 +1,46 @@
+import blinker
+from flask import Flask
+
+from alerta.exceptions import ApiError, RejectException
+
+hook_signals = blinker.Namespace()
+
+pre_receive_hook = hook_signals.signal('pre-receive')
+post_receive_hook = hook_signals.signal('post-receive')
+status_change_hook = hook_signals.signal('status-change')
+take_action_hook = hook_signals.signal('take-action')
+
+
+class HookTrigger:
+
+    def __init__(self, app: Flask=None) -> None:
+        self.app = app
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app: Flask) -> None:
+        pre_receive_hook.connect(self.process_pre_receive)
+        post_receive_hook.connect(self.process_post_receive)
+        status_change_hook.connect(self.process_status_change)
+        take_action_hook.connect(self.process_take_action)
+
+    def process_pre_receive(self, alert):
+        # not used
+        pass
+
+    def process_post_receive(self, alert):
+        # not used
+        pass
+
+    def process_status_change(self, alert, status, text):
+        from alerta.utils.api import process_status
+        try:
+            process_status(alert, status, text)
+        except RejectException as e:
+            raise ApiError(str(e), 400)
+        except Exception as e:
+            raise ApiError(str(e), 500)
+
+    def process_take_action(self, alert, action, text):
+        # not used
+        pass

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -122,6 +122,7 @@ class PluginsTestCase(unittest.TestCase):
         response = self.client.post('/alert', json=self.critical_alert, headers=self.headers)
         self.assertEqual(response.status_code, 201)
         data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['alert']['tags'], [])
 
         alert_id = data['id']
 
@@ -138,6 +139,7 @@ class PluginsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(data['alert']['status'], 'assign')
+        self.assertEqual(sorted(data['alert']['tags']), sorted(['this', 'the', 'other', 'that', 'more']))
         self.assertEqual(data['alert']['history'][2]['text'],
                          'ticket created by bob (ticket #12345)', data['alert']['history'])
 
@@ -156,7 +158,7 @@ class PluginsTestCase(unittest.TestCase):
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(data['alert']['status'], 'assign')
         self.assertEqual(data['alert']['attributes']['up'], 'down')
-        self.assertEqual(data['alert']['history'][3]['text'],
+        self.assertEqual(data['alert']['history'][4]['text'],
                          'ticket updated by bob (ticket #12345)', data['alert']['history'])
 
         # update ticket for alert
@@ -172,8 +174,8 @@ class PluginsTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(data['alert']['status'], 'closed')
-        self.assertEqual(data['alert']['tags'], ['true'])
-        self.assertEqual(data['alert']['history'][4]['text'],
+        self.assertIn('true', data['alert']['tags'])
+        self.assertEqual(data['alert']['history'][5]['text'],
                          'ticket resolved by bob (ticket #12345)', data['alert']['history'])
 
 


### PR DESCRIPTION
Trigger `status_change()` hook if the status is changed after receiving an alert. For example, the status can change for "closed" alerts that refire and change to "open" or if "open" alerts are cleared and become "closed".