### PR TITLE
Add default GitHub URL for OAuth2 provider

### DIFF
--- a/alerta/auth/github.py
+++ b/alerta/auth/github.py
@@ -15,12 +15,12 @@ from . import auth
 @cross_origin(supports_credentials=True)
 def github():
 
-    if current_app.config['GITHUB_URL']:
-        access_token_url = current_app.config['GITHUB_URL'] + '/login/oauth/access_token'
-        github_api_url = current_app.config['GITHUB_URL'] + '/api/v3'
-    else:
+    if current_app.config['GITHUB_URL'] == 'https://github.com':
         access_token_url = 'https://github.com/login/oauth/access_token'
         github_api_url = 'https://api.github.com'
+    else:
+        access_token_url = current_app.config['GITHUB_URL'] + '/login/oauth/access_token'
+        github_api_url = current_app.config['GITHUB_URL'] + '/api/v3'
 
     client_lookup = dict(zip(
         current_app.config['OAUTH2_CLIENT_ID'].split(','),

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -64,7 +64,7 @@ OAUTH2_CLIENT_ID = None  # Google, GitHub or GitLab OAuth2 client ID and secret
 OAUTH2_CLIENT_SECRET = None
 ALLOWED_EMAIL_DOMAINS = ['*']
 
-GITHUB_URL = None
+GITHUB_URL = 'https://github.com'
 ALLOWED_GITHUB_ORGS = ['*']
 
 GITLAB_URL = 'https://gitlab.com'


### PR DESCRIPTION
The default setting should make configuring Github OAuth2 easier for both web and CLI clients.