### PR TITLE
Added LDAP group support #749

### DIFF
--- a/alerta/auth/basic_ldap.py
+++ b/alerta/auth/basic_ldap.py
@@ -52,7 +52,20 @@ def login():
         raise ApiError('user not active', 403)
 
     # Assign customers & update last login time
-    customers = get_customers(user.email, groups=[user.domain])
+    groups = [user.domain]
+    try:
+        groups_filters = current_app.config.get('LDAP_DOMAINS_GROUP', {})
+        base_dns = current_app.config.get('LDAP_DOMAINS_BASEDN', {})
+        if domain in groups_filters and domain in base_dns:
+            resultID = ldap_connection.search(base_dns[domain], ldap.SCOPE_SUBTREE, \
+                                              groups_filters[domain] % username, ['cn'])
+            resultTypes, results = ldap_connection.result(resultID)
+            for _dn, attributes in results:
+                groups.append(attributes['cn'][0].decode("utf-8"))
+    except ldap.LDAPError as e:
+        raise ApiError(str(e), 500)
+
+    customers = get_customers(user.email, groups=groups)
     user.update_last_login()
 
     auth_audit_trail.send(current_app._get_current_object(), event='basic-ldap-login', message='user login via LDAP',

--- a/alerta/auth/basic_ldap.py
+++ b/alerta/auth/basic_ldap.py
@@ -58,7 +58,8 @@ def login():
         base_dns = current_app.config.get('LDAP_DOMAINS_BASEDN', {})
         if domain in groups_filters and domain in base_dns:
             resultID = ldap_connection.search(base_dns[domain], ldap.SCOPE_SUBTREE, \
-                                              groups_filters[domain] % username, ['cn'])
+                                              groups_filters[domain].format(username=username, email=email, userdn=userdn), \
+                                              ['cn'])
             resultTypes, results = ldap_connection.result(resultID)
             for _dn, attributes in results:
                 groups.append(attributes['cn'][0].decode("utf-8"))

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -72,6 +72,8 @@ ALLOWED_GITLAB_GROUPS = ['*']
 
 LDAP_URL = ''  # eg. ldap://localhost:389
 LDAP_DOMAINS = {}  # type: Dict[str, str]
+LDAP_DOMAINS_GROUP = {} # type: Dict[str, str]
+LDAP_DOMAINS_BASEDN = {} # type: Dict[str, str]
 
 PINGFEDERATE_URL = None
 PINGFEDERATE_OPENID_ACCESS_TOKEN_URL = PINGFEDERATE_URL


### PR DESCRIPTION
Closes #749


Example configuration:

```
LDAP_URL = 'ldap://localhost:389' 
LDAP_DOMAINS = {
    'example.com': 'uid=%s,ou=People,dc=example,dc=com'
}
LDAP_DOMAINS_GROUP = {
    'example.com': '(&(memberUid=%s)(objectClass=groupOfUniqueNames))'
}
LDAP_DOMAINS_BASEDN = {
    'example.com': 'dc=example,dc=com'
}
```