### PR TITLE
Use alert history to get most recent non-blackout status

### DIFF
--- a/alerta/database/base.py
+++ b/alerta/database/base.py
@@ -93,9 +93,6 @@ class Database(Base):
     def get_status(self, alert):
         raise NotImplementedError
 
-    def get_status_and_value(self, alert):
-        raise NotImplementedError
-
     def is_duplicate(self, alert):
         raise NotImplementedError
 
@@ -157,6 +154,9 @@ class Database(Base):
     # SEARCH & HISTORY
 
     def get_alerts(self, query=None, page=None, page_size=None):
+        raise NotImplementedError
+
+    def get_alert_history(self, alert, page=None, page_size=None):
         raise NotImplementedError
 
     def get_history(self, query=None, page=None, page_size=None):

--- a/alerta/models/alarms/__init__.py
+++ b/alerta/models/alarms/__init__.py
@@ -40,7 +40,7 @@ class AlarmModel(Base):
     def trend(self, previous, current):
         raise NotImplementedError
 
-    def transition(self, previous_severity, current_severity, previous_status=None, current_status=None, action=None, **kwargs):
+    def transition(self, alert, current_status=None, previous_status=None, action=None, **kwargs):
         raise NotImplementedError
 
     @staticmethod

--- a/alerta/models/alarms/alerta.py
+++ b/alerta/models/alarms/alerta.py
@@ -1,3 +1,4 @@
+from flask import current_app
 
 from alerta.models.alarms import AlarmModel
 
@@ -99,93 +100,133 @@ class StateMachine(AlarmModel):
         else:
             return NO_CHANGE
 
-    def transition(self, previous_severity, current_severity, previous_status=None, current_status=None, action=None, **kwargs):
+    def transition(self, alert, current_status=None, previous_status=None, action=None, **kwargs):
+
+        current_status = current_status or StateMachine.DEFAULT_STATUS
+        previous_status = previous_status or StateMachine.DEFAULT_STATUS
+
+        current_severity = alert.severity
+        previous_severity = alert.previous_severity or StateMachine.DEFAULT_PREVIOUS_SEVERITY
 
         assert current_severity in StateMachine.Severity, "'%s' is not a valid severity" % current_severity
+
+        print('current status (from db) = {} inbound status (from alert) = {}'.format(current_status, alert.status))
+
+        def next_state(rule, severity, status):
+            current_app.logger.info(
+                'State Transition: Rule #{} STATE={:8s} ACTION={:8s} '
+                'SEVERITY={:8s}-> {:8s} HISTORY={:8s}-> {:8s}-> {:8s} '
+                '=> SEVERITY={:8s}, STATUS={:8s}'.format(
+                    rule,
+                    current_status,
+                    action or '',
+                    previous_severity,
+                    current_severity,
+                    previous_status,
+                    current_status,
+                    alert.status,
+                    severity,
+                    status
+                ))
+            return severity, status
 
         # if an unrecognised action is passed then assume state transition has been handled
         # by a take_action() plugin and return the current severity and status unchanged
         if action and action not in ACTION_ALL:
-            return current_severity, current_status
+            return next_state('ACT-1', current_severity, alert.status)
 
-        previous_status = previous_status or StateMachine.DEFAULT_STATUS
-        state = current_status = current_status or StateMachine.DEFAULT_STATUS
+        if alert.status != StateMachine.DEFAULT_STATUS:
+            if StateMachine.Severity[current_severity] == NORMAL_SEVERITY_LEVEL:
+                return next_state('SET-1', StateMachine.DEFAULT_NORMAL_SEVERITY, CLOSED)
 
+            return next_state('SET-*', current_severity, alert.status)
+
+        state = current_status
         if state == OPEN:
             if action == ACTION_ACK:
-                return current_severity, ACK
+                return next_state('OPN-1', current_severity, ACK)
             if action == ACTION_SHELVE:
-                return current_severity, SHELVED
+                return next_state('OPN-2', current_severity, SHELVED)
             if action == ACTION_CLOSE:
-                return StateMachine.DEFAULT_NORMAL_SEVERITY, CLOSED
+                return next_state('OPN-3', StateMachine.DEFAULT_NORMAL_SEVERITY, CLOSED)
 
             if StateMachine.Severity[current_severity] == NORMAL_SEVERITY_LEVEL:
-                return StateMachine.DEFAULT_NORMAL_SEVERITY, CLOSED
-            if self.trend(previous_severity, current_severity) == MORE_SEVERE:
-                return current_severity, OPEN
-            if previous_status in [ACK, SHELVED]:
-                return current_severity, previous_status
-
-            # FIXME: this should return the status before it became blackout
-            # if previous_status == BLACKOUT:
-            #     return current_severity, OPEN
+                return next_state('OPN-4', StateMachine.DEFAULT_NORMAL_SEVERITY, CLOSED)
 
         if state == ASSIGN:
             pass
 
         if state == ACK:
-            if action in [ACTION_UNACK, ACTION_OPEN]:
-                return current_severity, OPEN
+            if action == ACTION_OPEN:
+                return next_state('ACK-1', current_severity, OPEN)
+            if action == ACTION_UNACK:
+                return next_state('ACK-2', current_severity, previous_status)
             if action == ACTION_SHELVE:
-                return current_severity, SHELVED
+                return next_state('ACK-3', current_severity, SHELVED)
             if action == ACTION_CLOSE:
-                return StateMachine.DEFAULT_NORMAL_SEVERITY, CLOSED
+                return next_state('ACK-4', StateMachine.DEFAULT_NORMAL_SEVERITY, CLOSED)
 
             if StateMachine.Severity[current_severity] == NORMAL_SEVERITY_LEVEL:
-                return StateMachine.DEFAULT_NORMAL_SEVERITY, CLOSED
+                return next_state('ACK-5', StateMachine.DEFAULT_NORMAL_SEVERITY, CLOSED)
+
+            if previous_severity == StateMachine.DEFAULT_PREVIOUS_SEVERITY:
+                return next_state('ACK-6', current_severity, ACK)
+
             if self.trend(previous_severity, current_severity) == MORE_SEVERE:
-                return current_severity, OPEN
+                return next_state('ACK-7', current_severity, OPEN)
             else:
-                return current_severity, previous_status
+                return next_state('ACK-8', current_severity, ACK)
 
         if state == SHELVED:
             if action == ACTION_OPEN:
-                return current_severity, OPEN
+                return next_state('SHL-1', current_severity, OPEN)
             if action == ACTION_ACK:
-                return current_severity, ACK
+                return next_state('SHL-2', current_severity, ACK)
             if action == ACTION_UNSHELVE:
-                return current_severity, previous_status
+                return next_state('SHL-3', current_severity, previous_status)
             if action == ACTION_CLOSE:
-                return StateMachine.DEFAULT_NORMAL_SEVERITY, CLOSED
+                return next_state('SHL-4', StateMachine.DEFAULT_NORMAL_SEVERITY, CLOSED)
 
             if StateMachine.Severity[current_severity] == NORMAL_SEVERITY_LEVEL:
-                return StateMachine.DEFAULT_NORMAL_SEVERITY, CLOSED
-            else:
-                return current_severity, previous_status
+                return next_state('SHL-5', StateMachine.DEFAULT_NORMAL_SEVERITY, CLOSED)
+
+            return next_state('SHL-*', current_severity, SHELVED)
 
         if state == BLACKOUT:
             if action == ACTION_OPEN:
-                return current_severity, OPEN
+                return next_state('BLK-1', current_severity, OPEN)
             if action == ACTION_ACK:
-                return current_severity, ACK
+                return next_state('BLK-2', current_severity, ACK)
+            if action == ACTION_SHELVE:
+                return next_state('BLK-3', current_severity, SHELVED)
             if action == ACTION_CLOSE:
-                return StateMachine.DEFAULT_NORMAL_SEVERITY, CLOSED
+                return next_state('BLK-4', StateMachine.DEFAULT_NORMAL_SEVERITY, CLOSED)
 
             if StateMachine.Severity[current_severity] == NORMAL_SEVERITY_LEVEL:
-                return StateMachine.DEFAULT_NORMAL_SEVERITY, CLOSED
+                return next_state('BLK-5', StateMachine.DEFAULT_NORMAL_SEVERITY, CLOSED)
+
+            if previous_status == CLOSED:
+                return next_state('BLK-6', current_severity, alert.status)
+            else:
+                return next_state('BLK-*', current_severity, previous_status)
 
         if state == CLOSED:
             if action == ACTION_OPEN:
-                return previous_severity, OPEN
+                return next_state('CLS-1', previous_severity, OPEN)
 
             if StateMachine.Severity[current_severity] != NORMAL_SEVERITY_LEVEL:
-                return previous_severity, OPEN
+                if previous_status == SHELVED:
+                    return next_state('CLS-2', previous_severity, previous_status)
+                else:
+                    return next_state('CLS-3', previous_severity, OPEN)
 
         if state == EXPIRED:
             if StateMachine.Severity[current_severity] != NORMAL_SEVERITY_LEVEL:
-                return current_severity, OPEN
+                return next_state('EXP-1', current_severity, OPEN)
+            else:
+                return next_state('EXP-2', StateMachine.DEFAULT_NORMAL_SEVERITY, CLOSED)
 
-        return current_severity, current_status
+        return next_state('ALL-*', current_severity, current_status)
 
     @staticmethod
     def is_suppressed(alert):

--- a/alerta/models/alarms/isa_18_2.py
+++ b/alerta/models/alarms/isa_18_2.py
@@ -93,10 +93,13 @@ class StateMachine(AlarmModel):
         else:
             return NO_CHANGE
 
-    def transition(self, previous_severity, current_severity, previous_status=None, current_status=None, action=None, **kwargs):
+    def transition(self, alert, current_status=None, previous_status=None, action=None, **kwargs):
 
         state = previous_status or StateMachine.DEFAULT_STATUS
         latched = kwargs.get('is_latched', False)
+
+        current_severity = alert.severity
+        previous_severity = alert.previous_severity
 
         # Alarm Occurs, Normal (A) -> Unack (B)
         if state == NORMAL:

--- a/alerta/models/alert.py
+++ b/alerta/models/alert.py
@@ -243,8 +243,6 @@ class Alert:
 
     # de-duplicate an alert
     def deduplicate(self) -> 'Alert':
-        print('dedup -> {}'.format(self.status))
-
         now = datetime.utcnow()
 
         status_history = self.get_status_and_value()
@@ -291,8 +289,6 @@ class Alert:
 
     # correlate an alert
     def update(self) -> 'Alert':
-        print('correlate -> {}'.format(self.status))
-
         now = datetime.utcnow()
 
         self.previous_severity = db.get_severity(self)
@@ -341,7 +337,6 @@ class Alert:
 
     # create an alert
     def create(self) -> 'Alert':
-        print('new -> {}'.format(self.status))
         trend_indication = alarm_model.trend(alarm_model.DEFAULT_PREVIOUS_SEVERITY, self.severity)
 
         _, self.status = alarm_model.transition(

--- a/alerta/models/alert.py
+++ b/alerta/models/alert.py
@@ -231,23 +231,37 @@ class Alert:
     def is_flapping(self, window: int=1800, count: int=2) -> bool:
         return db.is_flapping(self, window, count)
 
+    def get_status_and_value(self):
+        return [(h.status, h.value) for h in self.get_alert_history(self, page=1, page_size=10) if h.status]
+
+    @staticmethod
+    def _pop_hist(h, index=0):
+        try:
+            return h[index]
+        except IndexError:
+            return None, None
+
     # de-duplicate an alert
     def deduplicate(self) -> 'Alert':
+        print('dedup -> {}'.format(self.status))
+
         now = datetime.utcnow()
 
-        previous_status, previous_value = db.get_status_and_value(self)
+        status_history = self.get_status_and_value()
+        status, previous_value = self._pop_hist(status_history)
+        previous_status, _ = self._pop_hist(status_history, 1)
+
         _, new_status = alarm_model.transition(
-            previous_severity=self.severity,
-            current_severity=self.severity,
-            previous_status=previous_status,
-            current_status=self.status
+            alert=self,
+            current_status=status,
+            previous_status=previous_status
         )
 
         self.repeat = True
         self.last_receive_id = self.id
         self.last_receive_time = now
 
-        if new_status != previous_status:
+        if new_status != status:
             history_text = 'duplicate alert with status change'
             history = History(
                 id=self.id,
@@ -277,17 +291,21 @@ class Alert:
 
     # correlate an alert
     def update(self) -> 'Alert':
+        print('correlate -> {}'.format(self.status))
+
         now = datetime.utcnow()
 
         self.previous_severity = db.get_severity(self)
-        previous_status = db.get_status(self)
         self.trend_indication = alarm_model.trend(self.previous_severity, self.severity)
 
+        status_history = self.get_status_and_value()
+        status, _ = self._pop_hist(status_history)
+        previous_status, _ = self._pop_hist(status_history, 1)
+
         _, new_status = alarm_model.transition(
-            previous_severity=self.previous_severity,
-            current_severity=self.severity,
-            previous_status=previous_status,
-            current_status=self.status
+            alert=self,
+            current_status=status,
+            previous_status=previous_status
         )
 
         self.duplicate_count = 0
@@ -306,7 +324,7 @@ class Alert:
             update_time=self.create_time
         )]
 
-        if new_status != previous_status:
+        if new_status != status:
             history_text = 'correlated alert status change'
             history.append(History(
                 id=self.id,
@@ -323,12 +341,12 @@ class Alert:
 
     # create an alert
     def create(self) -> 'Alert':
-        if self.status == alarm_model.DEFAULT_STATUS:
-            _, self.status = alarm_model.transition(
-                previous_severity=alarm_model.DEFAULT_PREVIOUS_SEVERITY,
-                current_severity=self.severity
-            )
+        print('new -> {}'.format(self.status))
         trend_indication = alarm_model.trend(alarm_model.DEFAULT_PREVIOUS_SEVERITY, self.severity)
+
+        _, self.status = alarm_model.transition(
+            alert=self
+        )
 
         self.duplicate_count = 0
         self.repeat = False
@@ -443,6 +461,10 @@ class Alert:
     def find_all(query: Query=None, page: int=1, page_size: int=1000) -> List['Alert']:
         return [Alert.from_db(alert) for alert in db.get_alerts(query, page, page_size)]
 
+    @staticmethod
+    def get_alert_history(alert, page=1, page_size=100):
+        return [RichHistory.from_db(hist) for hist in db.get_alert_history(alert, page, page_size)]
+
     # list alert history
     @staticmethod
     def get_history(query: Query=None, page=1, page_size=1000) -> List[RichHistory]:
@@ -542,13 +564,15 @@ class Alert:
 
     def from_action(self, action: str, text: str='', timeout: int=None) -> 'Alert':
         self.timeout = timeout or current_app.config['ALERT_TIMEOUT']
-        previous_status = db.get_status(self)
+
+        status_history = self.get_status_and_value()
+        status, _ = self._pop_hist(status_history)
+        previous_status, _ = self._pop_hist(status_history, 1)
 
         new_severity, new_status = alarm_model.transition(
-            previous_severity=self.previous_severity,
-            current_severity=self.severity,
+            alert=self,
+            current_status=status,
             previous_status=previous_status,
-            current_status=self.status,
             action=action
         )
 

--- a/tests/test_shelving.py
+++ b/tests/test_shelving.py
@@ -82,12 +82,12 @@ class ShelvingTestCase(unittest.TestCase):
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(data['alert']['status'], 'shelved')
 
-        # increase severity alert should be status=open
+        # increase severity alert should stay status=shelved
         self.alert['severity'] = 'major'
         response = self.client.post('/alert', data=json.dumps(self.alert), headers=self.headers)
         self.assertEqual(response.status_code, 201)
         data = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(data['alert']['status'], 'open')
+        self.assertEqual(data['alert']['status'], 'shelved')
 
         # shelve alert
         response = self.client.put('/alert/' + alert_id + '/status',
@@ -133,12 +133,12 @@ class ShelvingTestCase(unittest.TestCase):
 
         ###
 
-        # increase severity alert should be status=open
+        # increase severity alert should be status=shelved
         self.alert['severity'] = 'critical'
         response = self.client.post('/alert', data=json.dumps(self.alert), headers=self.headers)
         self.assertEqual(response.status_code, 201)
         data = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(data['alert']['status'], 'open')
+        self.assertEqual(data['alert']['status'], 'shelved')
 
         # shelve alert
         response = self.client.put('/alert/' + alert_id + '/status',


### PR DESCRIPTION
>Hasso Tepper @hasso Dec 10 2018 11:02
@satterly at the moment if NOTIFICATION_BLACKOUT is set, alert.status is set to 'blackout' and it means that previous status is lost. It's not what I'd expect for acked alerts – ie after blackout is over, these alerts will be open again, not acked.
I'd probably wouldn't touch acked alerts at all in blackout plugin, but I might miss something and my quick attempt to fix it this way didn't work for some reason.

Alerts that have been ack'ed, shelved or suppressed due to a blackout should now return to their previous status once they have been unack'ed, unshelved or the blackout period has expired.

- [x] review all logic
- [x] review blackout special case (ie. using `self.status`)
- [x] fix take action logic
- [x] add tests for restoring to previous status from unack and un-shelve
