### PR TITLE
Lock version of pyparsing to 2.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
         'raven[flask]>=6.2.1',
         'pymongo>=3.0',
         'psycopg2',
-        'pyparsing',
+        'pyparsing==2.3.0',
         'requests',
         'python-dateutil',
         'pytz',


### PR DESCRIPTION
Something has changed with PyParsing v2.3.1 which is causing builds to fail.

https://github.com/pyparsing/pyparsing/compare/pyparsing_2.3.0..pyparsing_2.3.1