### PR TITLE
Make adding hashbang in links a server config option

### DIFF
--- a/alerta/auth/utils.py
+++ b/alerta/auth/utils.py
@@ -73,6 +73,13 @@ def create_token(user_id: str, name: str, login: str, provider: str, customers: 
     )
 
 
+def link(base_url, *parts):
+    if base_url.endswith('/'):
+        return urljoin(base_url, '/'.join(('#',) + parts))  # hashbang mode
+    else:
+        return urljoin(base_url, '/'.join(parts))  # html5 mode
+
+
 def send_confirmation(user: 'User', token: str) -> None:
     subject = "[Alerta] Please verify your email '%s'" % user.email
     text = 'Hello {name}!\n\n' \
@@ -80,7 +87,7 @@ def send_confirmation(user: 'User', token: str) -> None:
            '{url}\n\n' \
            'You\'re receiving this email because you recently created a new Alerta account.' \
            ' If this wasn\'t you, please ignore this email.'.format(
-               name=user.name, email=user.email, url=urljoin(request.referrer, '#/confirm/' + token)
+               name=user.name, email=user.email, url=link(request.referrer, 'confirm', token)
            )
     mailer.send_email(user.email, subject, body=text)
 
@@ -91,7 +98,7 @@ def send_password_reset(user: 'User', token: str) -> None:
            '{url}\n\n' \
            'You\'re receiving this email because you asked for a password reset of an Alerta account.' \
            ' If this wasn\'t you, please ignore this email.'.format(
-               name=user.name, email=user.email, url=urljoin(request.referrer, '#/reset/' + token)
+               name=user.name, email=user.email, url=link(request.referrer, 'reset', token)
            )
     mailer.send_email(user.email, subject, body=text)
 

--- a/alerta/views/__init__.py
+++ b/alerta/views/__init__.py
@@ -57,6 +57,7 @@ def config():
         'provider': current_app.config['AUTH_PROVIDER'],
         'customer_views': current_app.config['CUSTOMER_VIEWS'],
         'signup_enabled': current_app.config['SIGNUP_ENABLED'],
+        'email_verification': current_app.config['EMAIL_VERIFICATION'],
         'client_id': current_app.config['OAUTH2_CLIENT_ID'],
         'github_url': current_app.config['GITHUB_URL'],
         'gitlab_url': current_app.config['GITLAB_URL'],


### PR DESCRIPTION
AngularJS web console used "hashbang" mode. VueJS will use "history" mode, but with the ability to rewrite old URLs to new.

References
https://docs.angularjs.org/guide/$location#hashbang-and-html5-modes
https://router.vuejs.org/guide/essentials/history-mode.html