### PR TITLE
Use full path for namespaced GitLab groups

### DIFF
--- a/alerta/auth/gitlab.py
+++ b/alerta/auth/gitlab.py
@@ -55,7 +55,7 @@ def gitlab():
         login = profile['username']
 
         r = requests.get(gitlab_api_url + '/groups', headers=headers)
-        groups = [g['path'] for g in r.json()]
+        groups = [g['full_path'] for g in r.json()]
         email_verified = True if profile.get('email', None) else False
 
     if not_authorized('ALLOWED_GITLAB_GROUPS', groups):


### PR DESCRIPTION
Use `full_path` instead of just `path` when getting GitLab group names...

```
[
  {
    "id": 4497673,
    "web_url": "https://gitlab.com/groups/team-alerta/sdk",
    "name": "SDK",
    "path": "sdk",
    "description": "",
    "visibility": "private",
    "lfs_enabled": true,
    "avatar_url": null,
    "request_access_enabled": false,
    "full_name": "team-alerta / SDK",
    "full_path": "team-alerta/sdk",
    "parent_id": 4497657,
    "ldap_cn": null,
    "ldap_access": null
  },
  {
    "id": 4497657,
    "web_url": "https://gitlab.com/groups/team-alerta",
    "name": "team-alerta",
    "path": "team-alerta",
    "description": "",
    "visibility": "private",
    "lfs_enabled": true,
    "avatar_url": null,
    "request_access_enabled": false,
    "full_name": "team-alerta",
    "full_path": "team-alerta",
    "parent_id": null,
    "ldap_cn": null,
    "ldap_access": null
  }
]
```
Fixes #828 