### PR TITLE
Fix the handling of % in webhook bodies

### DIFF
--- a/alerta/webhooks/__init__.py
+++ b/alerta/webhooks/__init__.py
@@ -21,7 +21,7 @@ def before_request():
         request.method,
         request.url,
         request.headers,
-        request.get_data().decode('utf-8')
+        request.get_data().decode('utf-8').replace("%","%%")
     ))
 
 


### PR DESCRIPTION
Without this, % in the webhook bodies causes logging failures when the webhook body contains a %X that gets interpreted as a formatter by the python logging package (msg = msg % self.args).

In more detail: before_request in webhooks/__init__.py creates the message and passes it to the logger, but in the logger itself it also formats again (using %) *if* there are any args.  Interestingly, the args are  query params, so the previous tests didn't trigger this because there were none.  We triggered this in production because we were using api-key as a query param.  This is why the tests need to also have api-key changes.  

Also of note: the updated tests don't strictly fail without the fix in webhooks/__init__.py, they just write to stdout (the logging framework eats the formatting exception and spits out the entire failure to stdout); I don't know of any trivial way to make this properly fail in a test compatible fashion.  Also, I was unable to get it to fail/log poorly on anything other than the cloudwatch test (specifically, the first test).  I suspect something nose-related rather than the code, but I'm really not sure.  I am very happy to be enlightened if I'm missing something.