### PR TITLE
logger attribute

### DIFF
--- a/alerta/utils/webhook.py
+++ b/alerta/utils/webhook.py
@@ -20,7 +20,7 @@ class CustomWebhooks:
                 if webhook:
                     self.webhooks[ep.name] = webhook()
             except Exception as e:
-                app.log.warn('Failed to load custom webhook {} - {}'.format(ep.name, e))
+                app.logger.warn('Failed to load custom webhook {} - {}'.format(ep.name, e))
 
     def iter_rules(self):
         return iter([


### PR DESCRIPTION
Changing app.log to app.logger to avoid internal server error when loading broken webhook.