### PR TITLE
Fix log format of plugin init error

### DIFF
--- a/alerta/utils/plugin.py
+++ b/alerta/utils/plugin.py
@@ -36,7 +36,7 @@ class Plugins:
                     self.plugins[name] = plugin()
                     LOG.info("Server plugin '{}' loaded.".format(name))
             except Exception as e:
-                LOG.error("Failed to load plugin '{}': {}", name, e)
+                LOG.error("Failed to load plugin '{}': {}".format(name, str(e)))
         LOG.info('All server plugins enabled: {}'.format(', '.join(self.plugins.keys())))
         try:
             self.rules = load_entry_point('alerta-routing', 'alerta.routing', 'rules')  # type: ignore


### PR DESCRIPTION
Example of fixed error log message ...
```
2019-02-20 13:45:11,712 - alerta.plugins[25001]: ERROR - Failed to load plugin 'slack': 'SLACK_WEBHOOK_URL' [in /Users/nsatterl/Projects/alerta/alerta/utils/plugin.py:39]
```