### PR TITLE
mongo base warning

### DIFF
--- a/alerta/database/backends/mongodb/base.py
+++ b/alerta/database/backends/mongodb/base.py
@@ -29,7 +29,7 @@ class Backend(Database):
         if self.dbname:
             return self.client[self.dbname]
         else:
-            return self.client.get_default_database()
+            return self.client.get_database()
 
     @staticmethod
     def _create_indexes(db):


### PR DESCRIPTION
Address warning:

alerta/alerta/database/backends/mongodb/base.py:32: DeprecationWarning: get_default_database is deprecated. Use get_database instead.
    return self.client.get_default_database()