### PR TITLE
Add update time to alert model

### DIFF
--- a/alerta/database/base.py
+++ b/alerta/database/base.py
@@ -111,7 +111,7 @@ class Database(Base):
     def create_alert(self, alert):
         raise NotImplementedError
 
-    def set_alert(self, id, severity, status, tags, attributes, timeout, previous_severity, history=None):
+    def set_alert(self, id, severity, status, tags, attributes, timeout, previous_severity, update_time, history=None):
         raise NotImplementedError
 
     def get_alert(self, id, customers=None):
@@ -119,7 +119,7 @@ class Database(Base):
 
     # STATUS, TAGS, ATTRIBUTES
 
-    def set_status(self, id, status, timeout, history=None):
+    def set_status(self, id, status, timeout, update_time, history=None):
         raise NotImplementedError
 
     def tag_alert(self, id, tags):

--- a/alerta/sql/schema.sql
+++ b/alerta/sql/schema.sql
@@ -53,6 +53,12 @@ CREATE TABLE IF NOT EXISTS alerts (
     history history[]
 );
 
+DO $$
+BEGIN
+    ALTER TABLE alerts ADD COLUMN update_time text;
+EXCEPTION
+    WHEN duplicate_column THEN RAISE NOTICE 'column "update_time" already exists in alerts.';
+END$$;
 
 CREATE TABLE IF NOT EXISTS blackouts (
     id text PRIMARY KEY,


### PR DESCRIPTION
The `updateTime` attribute only changes when alert status changes. It can be used to calculate time remaining until an alert times out, no matter what status the alert is in.