### PR TITLE
Lock down python package versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ before_script:
   - sh -c "if [ '$DB' = 'postgres' ]; then psql -c 'CREATE DATABASE alerta5;' -U postgres; fi"
 
 install:
-  - pip install .
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
+  - pip install .
 
 script:
   - python -m mypy alerta/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,13 @@
-.
+bcrypt==3.1.4
+Flask==1.0.2
+Flask-Compress==1.4.0
+Flask-Cors==3.0.6
+psycopg2==2.7.5
+PyJWT==1.6.4
+pymongo==3.7.1
+pyparsing==2.3.1
+python-dateutil==2.7.3
+pytz==2018.5
+pyyaml==3.13
+raven[flask]==6.9.0
+requests==2.19.1


### PR DESCRIPTION
This is needed to guarantee repeatable builds and test results.