### PR TITLE
Add user groups for role and customer lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Requirements
 The only mandatory dependency is MongoDB or PostgreSQL. Everything else is optional.
 
 - Postgres version 9.5 or better
-- MongoDB version 3.x
+- MongoDB version 3.2 or better
 
 Installation
 ------------

--- a/alerta/database/base.py
+++ b/alerta/database/base.py
@@ -195,14 +195,14 @@ class Database(Base):
     def get_services(self, query=None, topn=1000):
         raise NotImplementedError
 
-    # GROUPS
+    # ALERT GROUPS
 
-    def get_groups(self, query=None, topn=1000):
+    def get_alert_groups(self, query=None, topn=1000):
         raise NotImplementedError
 
-    # TAGS
+    # ALERT TAGS
 
-    def get_tags(self, query=None, topn=1000):
+    def get_alert_tags(self, query=None, topn=1000):
         raise NotImplementedError
 
     # BLACKOUTS
@@ -289,6 +289,35 @@ class Database(Base):
         raise NotImplementedError
 
     def set_email_hash(self, id, hash):
+        raise NotImplementedError
+
+    # GROUPS
+
+    def create_group(self, group):
+        raise NotImplementedError
+
+    def get_group(self, id):
+        raise NotImplementedError
+
+    def get_group_users(self, id):
+        raise NotImplementedError
+
+    def get_groups(self, query=None):
+        raise NotImplementedError
+
+    def update_group(self, id, **kwargs):
+        raise NotImplementedError
+
+    def add_user_to_group(self, group, user):
+        raise NotImplementedError
+
+    def remove_user_from_group(self, group, user):
+        raise NotImplementedError
+
+    def delete_group(self, id):
+        raise NotImplementedError
+
+    def get_groups_by_user(self, user):
         raise NotImplementedError
 
     # PERMISSIONS

--- a/alerta/models/alert.py
+++ b/alerta/models/alert.py
@@ -530,12 +530,12 @@ class Alert:
     # get groups
     @staticmethod
     def get_groups(query: Query=None) -> List[str]:
-        return db.get_groups(query)
+        return db.get_alert_groups(query)
 
     # get tags
     @staticmethod
     def get_tags(query: Query=None) -> List[str]:
-        return db.get_tags(query)
+        return db.get_alert_tags(query)
 
     @staticmethod
     def housekeeping(expired_threshold: int=2, info_threshold: int=12) -> None:

--- a/alerta/models/enums.py
+++ b/alerta/models/enums.py
@@ -17,6 +17,8 @@ class Scope(str, Enum):
     admin_heartbeats = 'admin:heartbeats'
     write_users = 'write:users'
     admin_users = 'admin:users'
+    read_groups = 'read:groups'
+    admin_groups = 'admin:groups'
     read_perms = 'read:perms'
     admin_perms = 'admin:perms'
     read_customers = 'read:customers'

--- a/alerta/models/group.py
+++ b/alerta/models/group.py
@@ -1,0 +1,144 @@
+
+from typing import Any, Dict, List, Optional, Tuple, Union
+from uuid import uuid4
+
+from alerta.app import db
+from alerta.database.base import Query
+from alerta.utils.response import absolute_url
+
+JSON = Dict[str, Any]
+
+
+class GroupUser:
+
+    def __init__(self, id: str, login: str, name: str, status: str) -> None:
+        self.id = id
+        self.login = login
+        self.name = name
+        self.status = status
+
+    @property
+    def serialize(self) -> Dict[str, Any]:
+        return {
+            'id': self.id,
+            'href': absolute_url('/user/' + self.id),
+            'login': self.login,
+            'name': self.name,
+            'status': self.status
+        }
+
+    @classmethod
+    def from_document(cls, doc: Dict[str, Any]) -> 'GroupUser':
+        return GroupUser(
+            id=doc.get('id', None),
+            name=doc.get('name', None),
+            login=doc.get('login', None) or doc.get('email', None),
+            status=doc.get('status', None)
+        )
+
+    @classmethod
+    def from_record(cls, rec):
+        return GroupUser(
+            id=rec.id,
+            login=(rec.login or rec.email),
+            name=rec.name,
+            status=rec.status
+        )
+
+    @classmethod
+    def from_db(cls, r):
+        if isinstance(r, dict):
+            return cls.from_document(r)
+        elif isinstance(r, tuple):
+            return cls.from_record(r)
+
+
+class GroupUsers:
+
+    def __init__(self, id: str, users: List[GroupUser]) -> None:
+        self.id = id
+        self.users = users
+
+    @staticmethod
+    def find_by_id(id: str) -> List['GroupUser']:
+        return [GroupUser.from_db(user) for user in db.get_group_users(id)]
+
+
+class Group:
+    """
+    Group model.
+    """
+
+    def __init__(self, name: str, text: str, **kwargs) -> None:
+        if not name:
+            raise ValueError('Missing mandatory value for name')
+
+        self.id = kwargs.get('id', str(uuid4()))
+        self.name = name
+        self.text = text or ''
+
+    @classmethod
+    def parse(cls, json: JSON) -> 'Group':
+        return Group(
+            name=json.get('name', None),
+            text=json.get('text', None)
+        )
+
+    @property
+    def serialize(self) -> Dict[str, Any]:
+        return {
+            'id': self.id,
+            'href': absolute_url('/group/' + self.id),
+            'name': self.name,
+            'text': self.text
+        }
+
+    def __repr__(self) -> str:
+        return 'Group(id={!r}, name={!r}, text={!r})'.format(
+            self.id, self.name, self.text)
+
+    @classmethod
+    def from_document(cls, doc: Dict[str, Any]) -> 'Group':
+        return Group(
+            id=doc.get('id', None) or doc.get('_id'),
+            name=doc.get('name', None),
+            text=doc.get('text', None)
+        )
+
+    @classmethod
+    def from_record(cls, rec) -> 'Group':
+        return Group(
+            id=rec.id,
+            name=rec.name,
+            text=rec.text
+        )
+
+    @classmethod
+    def from_db(cls, r: Union[Dict, Tuple]) -> 'Group':
+        if isinstance(r, dict):
+            return cls.from_document(r)
+        elif isinstance(r, tuple):
+            return cls.from_record(r)
+
+    def create(self) -> 'Group':
+        return Group.from_db(db.create_group(self))
+
+    @staticmethod
+    def find_by_id(id: str) -> Optional['Group']:
+        return Group.from_db(db.get_group(id))
+
+    @staticmethod
+    def find_all(query: Query=None) -> List['Group']:
+        return [Group.from_db(group) for group in db.get_groups(query)]
+
+    def update(self, **kwargs) -> 'Group':
+        return Group.from_db(db.update_group(self.id, **kwargs))
+
+    def add_user(self, user_id):
+        return db.add_user_to_group(group=self.id, user=user_id)
+
+    def remove_user(self, user_id):
+        return db.remove_user_from_group(group=self.id, user=user_id)
+
+    def delete(self) -> bool:
+        return db.delete_group(self.id)

--- a/alerta/models/user.py
+++ b/alerta/models/user.py
@@ -8,6 +8,7 @@ from flask import current_app
 from alerta.app import db
 from alerta.auth import utils
 from alerta.database.base import Query
+from alerta.models.group import Group
 from alerta.utils.response import absolute_url
 
 JSON = Dict[str, Any]
@@ -162,6 +163,9 @@ class User:
 
     def delete(self) -> bool:
         return db.delete_user(self.id)
+
+    def get_groups(self):
+        return [Group.from_db(g) for g in db.get_groups_by_user(self.id)]
 
     @staticmethod
     def check_credentials(username: str, password: str) -> Optional['User']:

--- a/alerta/sql/schema.sql
+++ b/alerta/sql/schema.sql
@@ -174,6 +174,23 @@ CREATE TABLE IF NOT EXISTS users (
     hash text
 );
 
+DO $$
+BEGIN
+    ALTER TABLE users ADD COLUMN login text;
+EXCEPTION
+    WHEN duplicate_column THEN RAISE NOTICE 'column login already exists in users.';
+END$$;
+
+CREATE TABLE IF NOT EXISTS groups (
+    id text PRIMARY KEY,
+    name text UNIQUE NOT NULL,
+    users text[],
+    text text,
+    tags text[],
+    attributes jsonb,
+    update_time timestamp without time zone
+);
+
 
 CREATE UNIQUE INDEX IF NOT EXISTS env_res_evt_cust_key ON alerts USING btree (environment, resource, event, (COALESCE(customer, ''::text)));
 

--- a/alerta/views/__init__.py
+++ b/alerta/views/__init__.py
@@ -6,7 +6,7 @@ from flask import Blueprint, request, jsonify, current_app
 
 api = Blueprint('api', __name__)
 
-from . import alerts, blackouts, customers, heartbeats, keys, permissions, users, oembed  # noqa
+from . import alerts, blackouts, customers, groups, heartbeats, keys, permissions, users, oembed  # noqa
 
 try:
     from . import bulk  # noqa

--- a/alerta/views/alerts.py
+++ b/alerta/views/alerts.py
@@ -522,7 +522,7 @@ def get_services():
 
 
 # get alert groups
-@api.route('/groups', methods=['OPTIONS', 'GET'])
+@api.route('/alerts/groups', methods=['OPTIONS', 'GET'])
 @cross_origin()
 @permission(Scope.read_alerts)
 @timer(gets_timer)
@@ -547,7 +547,7 @@ def get_groups():
 
 
 # get alert tags
-@api.route('/tags', methods=['OPTIONS', 'GET'])
+@api.route('/alerts/tags', methods=['OPTIONS', 'GET'])
 @cross_origin()
 @permission(Scope.read_alerts)
 @timer(gets_timer)

--- a/alerta/views/groups.py
+++ b/alerta/views/groups.py
@@ -1,0 +1,182 @@
+from flask import current_app, g, jsonify, request
+from flask_cors import cross_origin
+
+from alerta.app import qb
+from alerta.auth.decorators import permission
+from alerta.exceptions import ApiError
+from alerta.models.enums import Scope
+from alerta.models.group import Group, GroupUsers
+from alerta.models.user import User
+from alerta.utils.audit import admin_audit_trail
+from alerta.utils.response import jsonp
+
+from . import api
+
+
+@api.route('/group', methods=['OPTIONS', 'POST'])
+@cross_origin()
+@permission(Scope.admin_groups)
+@jsonp
+def create_group():
+    try:
+        group = Group.parse(request.json)
+    except ValueError as e:
+        raise ApiError(str(e), 400)
+
+    try:
+        group = group.create()
+    except Exception as e:
+        raise ApiError(str(e), 500)
+
+    admin_audit_trail.send(current_app._get_current_object(), event='group-created', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=group.id, type='group', request=request)
+
+    if group:
+        return jsonify(status='ok', id=group.id, group=group.serialize), 201
+    else:
+        raise ApiError('create user group failed', 500)
+
+
+@api.route('/group/<group_id>', methods=['OPTIONS', 'GET'])
+@cross_origin()
+@permission(Scope.read_groups)
+@jsonp
+def get_group(group_id):
+    group = Group.find_by_id(group_id)
+
+    if group:
+        return jsonify(status='ok', total=1, group=group.serialize)
+    else:
+        raise ApiError('not found', 404)
+
+
+@api.route('/group/<group_id>/users', methods=['OPTIONS', 'GET'])
+@cross_origin()
+@permission(Scope.read_groups)
+@jsonp
+def get_group_users(group_id):
+    if not Group.find_by_id(group_id):
+        raise ApiError('not found', 404)
+
+    group_users = GroupUsers.find_by_id(group_id)
+
+    if group_users:
+        return jsonify(
+            status='ok',
+            users=[user.serialize for user in group_users],
+            total=len(group_users)
+        )
+    else:
+        return jsonify(
+            status='ok',
+            users=[],
+            total=0
+        )
+
+
+@api.route('/groups', methods=['OPTIONS', 'GET'])
+@cross_origin()
+@permission(Scope.read_groups)
+@jsonp
+def list_groups():
+    query = qb.from_params(request.args)
+    groups = Group.find_all(query)
+
+    if groups:
+        return jsonify(
+            status='ok',
+            groups=[group.serialize for group in groups],
+            total=len(groups)
+        )
+    else:
+        return jsonify(
+            status='ok',
+            message='not found',
+            groups=[],
+            total=0
+        )
+
+
+@api.route('/group/<group_id>', methods=['OPTIONS', 'PUT'])
+@cross_origin()
+@permission(Scope.admin_groups)
+@jsonp
+def update_group(group_id):
+    if not request.json:
+        raise ApiError('nothing to change', 400)
+
+    group = Group.find_by_id(group_id)
+
+    if not group:
+        raise ApiError('not found', 404)
+
+    admin_audit_trail.send(current_app._get_current_object(), event='group-updated', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=group.id, type='group', request=request)
+
+    if group.update(**request.json):
+        return jsonify(status='ok')
+    else:
+        raise ApiError('failed to update user group', 500)
+
+
+@api.route('/group/<group_id>/user/<user_id>', methods=['OPTIONS', 'PUT'])
+@cross_origin()
+@permission(Scope.admin_groups)
+@jsonp
+def add_user_to_group(group_id, user_id):
+    group = Group.find_by_id(group_id)
+    if not group:
+        raise ApiError('not found', 404)
+
+    user = User.find_by_id(user_id)
+    if not user:
+        raise ApiError('invalid user', 400)
+
+    admin_audit_trail.send(current_app._get_current_object(), event='user-attributes-updated', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=user.id, type='user', request=request)
+
+    if group.add_user(user_id):
+        return jsonify(status='ok')
+    else:
+        raise ApiError('failed to add user to group', 500)
+
+
+@api.route('/group/<group_id>/user/<user_id>', methods=['OPTIONS', 'DELETE'])
+@cross_origin()
+@permission(Scope.admin_groups)
+@jsonp
+def remove_user_from_group(group_id, user_id):
+    group = Group.find_by_id(group_id)
+    if not group:
+        raise ApiError('not found', 404)
+
+    user = User.find_by_id(user_id)
+    if not user:
+        raise ApiError('invalid user', 400)
+
+    admin_audit_trail.send(current_app._get_current_object(), event='user-attributes-updated', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=user.id, type='user', request=request)
+
+    if group.remove_user(user_id):
+        return jsonify(status='ok')
+    else:
+        raise ApiError('failed to remove user from group', 500)
+
+
+@api.route('/group/<group_id>', methods=['OPTIONS', 'DELETE'])
+@cross_origin()
+@permission(Scope.admin_groups)
+@jsonp
+def delete_group(group_id):
+    group = Group.find_by_id(group_id)
+
+    if not group:
+        raise ApiError('not found', 404)
+
+    admin_audit_trail.send(current_app._get_current_object(), event='group-deleted', message='', user=g.user,
+                           customers=g.customers, scopes=g.scopes, resource_id=group.id, type='group', request=request)
+
+    if group.delete():
+        return jsonify(status='ok')
+    else:
+        raise ApiError('failed to delete user group', 500)

--- a/alerta/views/users.py
+++ b/alerta/views/users.py
@@ -72,6 +72,32 @@ def get_user(user_id):
         raise ApiError('not found', 404)
 
 
+@api.route('/user/<user_id>/groups', methods=['OPTIONS', 'GET'])
+@cross_origin()
+@permission(Scope.admin_users)
+@jsonp
+def get_user_groups(user_id):
+    user = User.find_by_id(user_id)
+    if not user:
+        raise ApiError('not found', 404)
+
+    user_groups = user.get_groups()
+
+    if user_groups:
+        return jsonify(
+            status='ok',
+            groups=[group.serialize for group in user_groups],
+            total=len(user_groups)
+        )
+    else:
+        return jsonify(
+            status='ok',
+            message='not found',
+            groups=[],
+            total=0
+        )
+
+
 @api.route('/user/me', methods=['OPTIONS', 'GET'])
 @cross_origin()
 @permission()

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 from alerta.app import alarm_model, create_app, db
 
 
-class AlertTestCase(unittest.TestCase):
+class ActionsTestCase(unittest.TestCase):
 
     def setUp(self):
 

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 from alerta.app import alarm_model, create_app, db
 
 
-class AlertTestCase(unittest.TestCase):
+class AlertsTestCase(unittest.TestCase):
 
     def setUp(self):
 
@@ -694,13 +694,22 @@ class AlertTestCase(unittest.TestCase):
         self.assertEqual(data['services'][0]['statusCounts'], {'open': 1, 'closed': 1})
 
         # groups
-        response = self.client.get('/groups')
+        response = self.client.get('/alerts/groups')
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode('utf-8'))
         self.assertIn('groups', data)
         self.assertEqual(data['groups'][0]['environment'], 'Production')
         self.assertEqual(data['groups'][0]['group'], 'Misc')
         self.assertEqual(data['groups'][0]['count'], 2)
+
+        # tags
+        response = self.client.get('/alerts/tags')
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertIn('tags', data)
+        self.assertEqual(data['tags'][0]['environment'], 'Production')
+        self.assertEqual(data['tags'][0]['tag'], 'foo')
+        self.assertEqual(data['tags'][0]['count'], 1)
 
     def test_query_param(self):
         # create alert

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -7,7 +7,7 @@ from flask_cors.extension import ACL_ALLOW_HEADERS, ACL_ORIGIN
 from alerta.app import create_app, db
 
 
-class AlertTestCase(unittest.TestCase):
+class HTTPCorsTestCase(unittest.TestCase):
 
     def setUp(self):
 

--- a/tests/test_customers.py
+++ b/tests/test_customers.py
@@ -11,7 +11,7 @@ from alerta.models.key import ApiKey
 from alerta.utils.api import assign_customer
 
 
-class AuthTestCase(unittest.TestCase):
+class CustomersTestCase(unittest.TestCase):
 
     def setUp(self):
 

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -1,0 +1,192 @@
+
+import json
+import unittest
+
+from alerta.app import create_app, db
+from alerta.models.enums import Scope
+from alerta.models.key import ApiKey
+
+
+class GroupsTestCase(unittest.TestCase):
+
+    def setUp(self):
+
+        test_config = {
+            'TESTING': True,
+            'AUTH_REQUIRED': True,
+            'ADMIN_USERS': ['admin@alerta.io'],
+            'ALLOWED_EMAIL_DOMAINS': ['alerta.io', 'doe.com']
+        }
+        self.app = create_app(test_config)
+        self.client = self.app.test_client()
+
+        self.alert = {
+            'event': 'Foo',
+            'resource': 'Bar',
+            'environment': 'Production',
+            'service': ['Quux']
+        }
+
+        with self.app.test_request_context('/'):
+            self.app.preprocess_request()
+            self.api_key = ApiKey(
+                user='admin@alerta.io',
+                scopes=[Scope.admin, Scope.read, Scope.write],
+                text='demo-key'
+            )
+            self.api_key.create()
+
+        self.headers = {
+            'Authorization': 'Key %s' % self.api_key.key,
+            'Content-type': 'application/json'
+        }
+
+    def tearDown(self):
+        db.destroy()
+
+    def test_groups(self):
+
+        # create a group
+        payload = {
+            'name': 'Group 1',
+            'text': 'Test group #1'
+        }
+        response = self.client.post('/group', data=json.dumps(payload), headers=self.headers)
+        self.assertEqual(response.status_code, 201, response.data)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['group']['name'], 'Group 1')
+        self.assertEqual(data['group']['text'], 'Test group #1')
+
+        group_id = data['group']['id']
+
+        # get group
+        response = self.client.get('/group/' + group_id, headers=self.headers)
+        self.assertEqual(response.status_code, 200, response.data)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['group']['name'], 'Group 1')
+        self.assertEqual(data['group']['text'], 'Test group #1')
+
+        # create a duplicate group name
+        # payload = {
+        #     'name': 'Group 1',
+        #     'text': 'Test group #1 duplicate'
+        # }
+        # response = self.client.post('/group', data=json.dumps(payload), headers=self.headers)
+        # self.assertEqual(response.status_code, 500, response.data)
+
+        # update a group name, text
+        payload = {
+            'name': 'Group 1 changed',
+            'text': 'Test group #1 changed too'
+        }
+        response = self.client.put('/group/' + group_id, data=json.dumps(payload), headers=self.headers)
+        self.assertEqual(response.status_code, 200, response.data)
+
+        response = self.client.get('/group/' + group_id, headers=self.headers)
+        self.assertEqual(response.status_code, 200, response.data)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['group']['name'], 'Group 1 changed')
+        self.assertEqual(data['group']['text'], 'Test group #1 changed too')
+
+        # create a different group
+        payload = {
+            'name': 'Group 2',
+            'text': 'Test group #2'
+        }
+        response = self.client.post('/group', data=json.dumps(payload), headers=self.headers)
+        self.assertEqual(response.status_code, 201, response.data)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['group']['name'], 'Group 2')
+        self.assertEqual(data['group']['text'], 'Test group #2')
+
+        group2_id = data['group']['id']
+
+        # list groups
+        response = self.client.get('/groups', headers=self.headers)
+        self.assertEqual(response.status_code, 200, response.data)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertListEqual([g['name'] for g in data['groups']], ['Group 1 changed', 'Group 2'])
+
+        # create a user
+        payload = {
+            'name': 'John Doe',
+            'email': 'john@doe.com',
+            'password': 'p8ssw0rd',
+            'roles': ['operator'],
+            'text': 'devops user'
+        }
+
+        response = self.client.post('/user', data=json.dumps(payload), headers=self.headers)
+        self.assertEqual(response.status_code, 201, response.data)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['user']['name'], 'John Doe')
+
+        user_id = data['user']['id']
+
+        # add a user to first group
+        response = self.client.put('/group/' + group_id + '/user/' + user_id, headers=self.headers)
+        self.assertEqual(response.status_code, 200, response.data)
+        data = json.loads(response.data.decode('utf-8'))
+
+        # get users for first group
+        response = self.client.get('/group/' + group_id + '/users', headers=self.headers)
+        self.assertEqual(response.status_code, 200, response.data)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertListEqual([u['name'] for u in data['users']], ['John Doe'])
+
+        # create another user
+        payload = {
+            'name': 'Jane Doe',
+            'email': 'jane@doe.com',
+            'password': 'p8ssw0rd',
+            'roles': ['manager'],
+            'text': 'manager'
+        }
+
+        response = self.client.post('/user', data=json.dumps(payload), headers=self.headers)
+        self.assertEqual(response.status_code, 201, response.data)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['user']['name'], 'Jane Doe')
+
+        user2_id = data['user']['id']
+
+        # add another user to first group
+        response = self.client.put('/group/' + group_id + '/user/' + user2_id, headers=self.headers)
+        self.assertEqual(response.status_code, 200, response.data)
+        data = json.loads(response.data.decode('utf-8'))
+
+        # get users for first group again
+        response = self.client.get('/group/' + group_id + '/users', headers=self.headers)
+        self.assertEqual(response.status_code, 200, response.data)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertListEqual([u['name'] for u in data['users']], ['John Doe', 'Jane Doe'])
+
+        # add second user to second group
+        response = self.client.put('/group/' + group2_id + '/user/' + user2_id, headers=self.headers)
+        self.assertEqual(response.status_code, 200, response.data)
+        data = json.loads(response.data.decode('utf-8'))
+
+        # get users for second group
+        response = self.client.get('/group/' + group2_id + '/users', headers=self.headers)
+        self.assertEqual(response.status_code, 200, response.data)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertListEqual([u['name'] for u in data['users']], ['Jane Doe'])
+
+        # get groups for first user
+        response = self.client.get('/user/' + user_id + '/groups', headers=self.headers)
+        self.assertEqual(response.status_code, 200, response.data)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertListEqual([g['name'] for g in data['groups']], ['Group 1 changed'])
+
+        # get groups for second user
+        response = self.client.get('/user/' + user2_id + '/groups', headers=self.headers)
+        self.assertEqual(response.status_code, 200, response.data)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertListEqual([g['name'] for g in data['groups']], ['Group 1 changed', 'Group 2'])
+
+        # delete groups
+        response = self.client.delete('/group/' + group_id, headers=self.headers)
+        self.assertEqual(response.status_code, 200, response.data)
+
+        response = self.client.delete('/group/' + group2_id, headers=self.headers)
+        self.assertEqual(response.status_code, 200, response.data)

--- a/tests/test_heartbeats.py
+++ b/tests/test_heartbeats.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 from alerta.app import create_app, db
 
 
-class HeartbeatTestCase(unittest.TestCase):
+class HeartbeatsTestCase(unittest.TestCase):
 
     def setUp(self):
 

--- a/tests/test_isa_18_2.py
+++ b/tests/test_isa_18_2.py
@@ -5,7 +5,7 @@ from alerta.app import alarm_model, create_app, db, plugins
 from alerta.plugins import PluginBase
 
 
-class AlertTestCase(unittest.TestCase):
+class Isa182TestCase(unittest.TestCase):
 
     def setUp(self):
 

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 from alerta.app import create_app, db
 
 
-class AlertTestCase(unittest.TestCase):
+class ManagementTestCase(unittest.TestCase):
 
     def setUp(self):
 

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -8,7 +8,7 @@ from alerta.models.key import ApiKey
 from alerta.models.permission import Permission
 
 
-class ScopeTestCase(unittest.TestCase):
+class ScopesTestCase(unittest.TestCase):
 
     def setUp(self):
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 from alerta.app import create_app, db
 
 
-class TagTestCase(unittest.TestCase):
+class TagsTestCase(unittest.TestCase):
 
     def setUp(self):
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -7,7 +7,7 @@ from alerta.models.enums import Scope
 from alerta.models.key import ApiKey
 
 
-class UserTestCase(unittest.TestCase):
+class UsersTestCase(unittest.TestCase):
 
     def setUp(self):
 


### PR DESCRIPTION
IMPORTANT: Breaking change to API. `/groups` added in #864 has moved to `/alerts/groups` (so that this resource could use `/groups`) and `/tags` has moved to `/alerts/tags` (for consistency).