### PR TITLE
Add comments explaining auto-unshelve status transitions

### DIFF
--- a/alerta/models/alarms/alerta.py
+++ b/alerta/models/alarms/alerta.py
@@ -161,6 +161,7 @@ class StateMachine(AlarmModel):
 
         if action == ACTION_UNSHELVE:
             if state == SHELVED:
+                # as per ISA 18.2 recommendation 11.7.3 manually unshelved alarms transition to previous status
                 return next_state('UNSHL-1', current_severity, previous_status)
             else:
                 raise InvalidAction('invalid action for current {} status'.format(state))

--- a/alerta/models/alert.py
+++ b/alerta/models/alert.py
@@ -547,7 +547,7 @@ class Alert:
                 id=last_receive_id,
                 event=event,
                 status='expired',
-                text='expired after timeout',
+                text='auto-expired after timeout',
                 change_type='status',
                 update_time=now,
                 user=g.login
@@ -555,11 +555,12 @@ class Alert:
             db.set_status(id, 'expired', timeout=current_app.config['ALERT_TIMEOUT'], update_time=now, history=history)
 
         for (id, event, last_receive_id) in unshelved:
+            # as per ISA 18.2 recommendation 11.7.3 auto-unshelved alarms transition to open, not previous status
             history = History(
                 id=last_receive_id,
                 event=event,
                 status='open',
-                text='unshelved after timeout',
+                text='auto-unshelved after timeout',
                 change_type='status',
                 update_time=now,
                 user=g.login


### PR DESCRIPTION
>11.7.3 Alarm shelving functional recommendations
The alarm shelving function should be designed to prevent alarm floods when active alarms
are automatically unshelved.
a) a manually unshelved alarm should transition to the acknowledged alarm state, and
b) an automatically unshelved alarm should transition to the unacknowledged alarm state.