### PR TITLE
Fix status change hook alert context

### DIFF
--- a/alerta/database/backends/mongodb/base.py
+++ b/alerta/database/backends/mongodb/base.py
@@ -121,7 +121,8 @@ class Backend(Database):
             'severity': alert.severity,
             'customer': alert.customer
         }
-        return bool(self.get_db().alerts.find_one(query))
+        r = self.get_db().alerts.find_one(query, projection={'_id': 1})
+        return r['_id'] if r else False
 
     def is_correlated(self, alert):
         query = {
@@ -138,7 +139,8 @@ class Backend(Database):
                 }],
             'customer': alert.customer
         }
-        return bool(self.get_db().alerts.find_one(query))
+        r = self.get_db().alerts.find_one(query, projection={'_id': 1})
+        return r['_id'] if r else False
 
     def is_flapping(self, alert, window=1800, count=2):
         """

--- a/alerta/database/backends/mongodb/base.py
+++ b/alerta/database/backends/mongodb/base.py
@@ -121,8 +121,7 @@ class Backend(Database):
             'severity': alert.severity,
             'customer': alert.customer
         }
-        r = self.get_db().alerts.find_one(query, projection={'_id': 1})
-        return r['_id'] if r else False
+        return self.get_db().alerts.find_one(query)
 
     def is_correlated(self, alert):
         query = {
@@ -139,8 +138,7 @@ class Backend(Database):
                 }],
             'customer': alert.customer
         }
-        r = self.get_db().alerts.find_one(query, projection={'_id': 1})
-        return r['_id'] if r else False
+        return self.get_db().alerts.find_one(query)
 
     def is_flapping(self, alert, window=1800, count=2):
         """

--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -171,7 +171,8 @@ class Backend(Database):
                AND severity=%(severity)s
                AND {customer}
             """.format(customer='customer=%(customer)s' if alert.customer else 'customer IS NULL')
-        return bool(self._fetchone(select, vars(alert)))
+        r = self._fetchone(select, vars(alert))
+        return r.id if r else False
 
     def is_correlated(self, alert):
         select = """
@@ -181,7 +182,8 @@ class Backend(Database):
                 OR (event!=%(event)s AND %(event)s=ANY(correlate)))
                AND {customer}
         """.format(customer='customer=%(customer)s' if alert.customer else 'customer IS NULL')
-        return bool(self._fetchone(select, vars(alert)))
+        r = self._fetchone(select, vars(alert))
+        return r.id if r else False
 
     def is_flapping(self, alert, window=1800, count=2):
         """

--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -164,26 +164,24 @@ class Backend(Database):
 
     def is_duplicate(self, alert):
         select = """
-            SELECT id FROM alerts
+            SELECT * FROM alerts
              WHERE environment=%(environment)s
                AND resource=%(resource)s
                AND event=%(event)s
                AND severity=%(severity)s
                AND {customer}
             """.format(customer='customer=%(customer)s' if alert.customer else 'customer IS NULL')
-        r = self._fetchone(select, vars(alert))
-        return r.id if r else False
+        return self._fetchone(select, vars(alert))
 
     def is_correlated(self, alert):
         select = """
-            SELECT id FROM alerts
+            SELECT * FROM alerts
              WHERE environment=%(environment)s AND resource=%(resource)s
                AND ((event=%(event)s AND severity!=%(severity)s)
                 OR (event!=%(event)s AND %(event)s=ANY(correlate)))
                AND {customer}
         """.format(customer='customer=%(customer)s' if alert.customer else 'customer IS NULL')
-        r = self._fetchone(select, vars(alert))
-        return r.id if r else False
+        return self._fetchone(select, vars(alert))
 
     def is_flapping(self, alert, window=1800, count=2):
         """

--- a/alerta/models/alert.py
+++ b/alerta/models/alert.py
@@ -237,11 +237,13 @@ class Alert:
         elif isinstance(r, tuple):
             return cls.from_record(r)
 
-    def is_duplicate(self) -> bool:
-        return db.is_duplicate(self)
+    def is_duplicate(self) -> Optional['Alert']:
+        """Return duplicate alert or None"""
+        return Alert.from_db(db.is_duplicate(self))
 
-    def is_correlated(self) -> bool:
-        return db.is_correlated(self)
+    def is_correlated(self) -> Optional['Alert']:
+        """Return correlated alert or None"""
+        return Alert.from_db(db.is_correlated(self))
 
     def is_flapping(self, window: int=1800, count: int=2) -> bool:
         return db.is_flapping(self, window, count)
@@ -281,20 +283,22 @@ class Alert:
         self.last_receive_time = now
 
         if new_status != status:
+            text = 'duplicate alert (with status change)'
+            r = status_change_hook.send(duplicate_of, status=new_status, text=text)
+            _, (_, new_status, text) = r[0]
+            self.update_time = now
+
             history = History(
                 id=self.id,
                 event=self.event,
                 severity=self.severity,
                 status=new_status,
                 value=self.value,
-                text='duplicate alert (with status change)',
+                text=text,
                 change_type='status',
                 update_time=self.create_time,
                 user=g.login,
             )  # type: Optional[History]
-
-            status_change_hook.send(Alert.find_by_id(duplicate_of), status=new_status, text=self.text)
-            self.update_time = now
 
         elif current_app.config['HISTORY_ON_VALUE_CHANGE'] and self.value != previous_value:
             history = History(
@@ -334,6 +338,12 @@ class Alert:
         self.receive_time = now
         self.last_receive_id = self.id
         self.last_receive_time = now
+        text = 'correlated alert'
+
+        if new_status != status:
+            r = status_change_hook.send(correlate_with, status=new_status, text=text)
+            _, (_, new_status, text) = r[0]
+            self.update_time = now
 
         history = [History(
             id=self.id,
@@ -341,15 +351,11 @@ class Alert:
             severity=self.severity,
             status=new_status,
             value=self.value,
-            text='correlated alert',
+            text=text,
             change_type='severity',
             update_time=self.create_time,
             user=g.login
         )]
-
-        if new_status != status:
-            status_change_hook.send(Alert.find_by_id(correlate_with), status=new_status, text=self.text)
-            self.update_time = now
 
         self.status = new_status
         return Alert.from_db(db.correlate_alert(self, history))
@@ -608,6 +614,9 @@ class Alert:
             action=action
         )
 
+        r = status_change_hook.send(self, status=new_status, text=text)
+        _, (_, new_status, text) = r[0]
+
         history = [History(
             id=self.id,
             event=self.event,
@@ -619,7 +628,6 @@ class Alert:
             update_time=now,
             user=g.login
         )]
-        status_change_hook.send(self, status=new_status, text=text)
 
         return Alert.from_db(db.set_alert(
             id=self.id,

--- a/alerta/models/alert.py
+++ b/alerta/models/alert.py
@@ -265,7 +265,7 @@ class Alert:
         return None, None, None
 
     # de-duplicate an alert
-    def deduplicate(self) -> 'Alert':
+    def deduplicate(self, duplicate_of) -> 'Alert':
         now = datetime.utcnow()
 
         status, previous_value, previous_status = self._get_hist_info()
@@ -292,9 +292,9 @@ class Alert:
                 update_time=self.create_time,
                 user=g.login,
             )  # type: Optional[History]
-            self.update_time = now
 
-            status_change_hook.send(self, status=new_status, text=self.text)
+            status_change_hook.send(Alert.find_by_id(duplicate_of), status=new_status, text=self.text)
+            self.update_time = now
 
         elif current_app.config['HISTORY_ON_VALUE_CHANGE'] and self.value != previous_value:
             history = History(
@@ -315,7 +315,7 @@ class Alert:
         return Alert.from_db(db.dedup_alert(self, history))
 
     # correlate an alert
-    def update(self) -> 'Alert':
+    def update(self, correlate_with) -> 'Alert':
         now = datetime.utcnow()
 
         self.previous_severity = db.get_severity(self)
@@ -348,7 +348,7 @@ class Alert:
         )]
 
         if new_status != status:
-            status_change_hook.send(self, status=new_status, text=self.text)
+            status_change_hook.send(Alert.find_by_id(correlate_with), status=new_status, text=self.text)
             self.update_time = now
 
         self.status = new_status

--- a/alerta/utils/api.py
+++ b/alerta/utils/api.py
@@ -56,13 +56,14 @@ def process_alert(alert: Alert) -> Alert:
 
     try:
         is_duplicate = alert.is_duplicate()
-        is_correlated = alert.is_correlated()
         if is_duplicate:
             alert = alert.deduplicate(is_duplicate)
-        elif is_correlated:
-            alert = alert.update(is_correlated)
         else:
-            alert = alert.create()
+            is_correlated = alert.is_correlated()
+            if is_correlated:
+                alert = alert.update(is_correlated)
+            else:
+                alert = alert.create()
     except Exception as e:
         raise ApiError(str(e))
 

--- a/alerta/utils/api.py
+++ b/alerta/utils/api.py
@@ -55,10 +55,12 @@ def process_alert(alert: Alert) -> Alert:
             raise SyntaxError("Plugin '%s' pre-receive hook did not return modified alert" % plugin.name)
 
     try:
-        if alert.is_duplicate():
-            alert = alert.deduplicate()
-        elif alert.is_correlated():
-            alert = alert.update()
+        is_duplicate = alert.is_duplicate()
+        is_correlated = alert.is_correlated()
+        if is_duplicate:
+            alert = alert.deduplicate(is_duplicate)
+        elif is_correlated:
+            alert = alert.update(is_correlated)
         else:
             alert = alert.create()
     except Exception as e:

--- a/alerta/utils/hooks.py
+++ b/alerta/utils/hooks.py
@@ -35,11 +35,16 @@ class HookTrigger:
     def process_status_change(self, alert, status, text):
         from alerta.utils.api import process_status
         try:
-            process_status(alert, status, text)
+            alert, status, text = process_status(alert, status, text)
         except RejectException as e:
             raise ApiError(str(e), 400)
         except Exception as e:
             raise ApiError(str(e), 500)
+
+        alert.tag(alert.tags)
+        alert.update_attributes(alert.attributes)
+
+        return alert, status, text
 
     def process_take_action(self, alert, action, text):
         # not used


### PR DESCRIPTION
For duplicate or correlated alerts, run the status change hook in the context of the duplicate or correlated alert from the database, not the alert that was sent. This means that any attributes or tags (or other alert information) associated with the existing alert is accessible to the status change plugin.

However, it means any attributes or tags in the sent alert are not accessible. This could be a problem, though all the tests pass so it's not a use-case I am familiar with. This is not to say anyone isn't using status change plugin in this way already so this could be creating more problems than it solves.

Fixes #939 