### PR TITLE
Ensure user login is not null

### DIFF
--- a/alerta/sql/schema.sql
+++ b/alerta/sql/schema.sql
@@ -178,6 +178,8 @@ ALTER TABLE users ALTER COLUMN email DROP NOT NULL;
 DO $$
 BEGIN
     ALTER TABLE users ADD COLUMN login text;
+    UPDATE users SET login = email;
+    ALTER TABLE users ALTER COLUMN login SET NOT NULL;
 EXCEPTION
     WHEN duplicate_column THEN RAISE NOTICE 'column login already exists in users.';
 END$$;


### PR DESCRIPTION
See #948 which removed the null constraint on email. It should not be possible to have a null email column when copying email to login, and then making login not null.