### PR TITLE
Change LDAP base domain string format

### DIFF
--- a/alerta/auth/basic_ldap.py
+++ b/alerta/auth/basic_ldap.py
@@ -28,7 +28,7 @@ def login():
     if domain not in current_app.config['LDAP_DOMAINS']:
         raise ApiError('unauthorized domain', 403)
 
-    userdn = current_app.config['LDAP_DOMAINS'][domain] % username
+    userdn = current_app.config['LDAP_DOMAINS'][domain].format(username)
 
     # Attempt LDAP AUTH
     try:


### PR DESCRIPTION
This is a simple solution suggest in the issue #951.

I don't find docs in this repo for adjusts de docs, but with this change th setup of LDAP_DOMAINS change from "uid=%s,cn=users,dc=mycompany,dc=com" to "uid={0},cn=users,dc=mycompany,dc=com"