### PR TITLE
Postgres as an "extra" optional install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setuptools.setup(
         'Flask-Compress>=1.4.0',
         'raven[flask]>=6.2.1',
         'pymongo>=3.0',
-        'psycopg2',
         'pyparsing',
         'requests',
         'python-dateutil',
@@ -52,6 +51,10 @@ setuptools.setup(
         'pyyaml',
         'bcrypt'
     ],
+    extras_require={
+        'mongodb': ['pymongo>=3.0'],
+        'postgres': ['psycopg2']
+    },
     include_package_data=True,
     zip_safe=False,
     entry_points={


### PR DESCRIPTION
**To install Alerta and use MongoDB backend...**
```
$ pip install alerta-server
```
or
```
$ pip install alerta-server[mongodb]
```

**To install Alerta and use Postgres backend ...**
```
$ pip install alerta-server[postgres]
```
or 
```
$ pip install alerta-server psycopg2
```
or (not recommended for production systems)
```
$ pip install alerta-server psycopg2-binary
```
Fixes #967 