### PR TITLE
Add built-in acked-by plugin

### DIFF
--- a/alerta/plugins/acked_by.py
+++ b/alerta/plugins/acked_by.py
@@ -1,0 +1,32 @@
+import logging
+
+from flask import g
+
+from alerta.plugins import PluginBase
+
+LOG = logging.getLogger('alerta.plugins')
+
+
+class AckedBy(PluginBase):
+    """
+    Add "acked-by" attribute to alerts when an operator acknowledges alert and
+    unset the attribute when alert is unacknowledged. To display the current
+    value in the alert summary add "acked-by" to the COLUMNS server setting.
+    """
+
+    def pre_receive(self, alert, **kwargs):
+        return alert
+
+    def post_receive(self, alert, **kwargs):
+        return
+
+    def status_change(self, alert, status, text, **kwargs):
+        return
+
+    def take_action(self, alert, action, text, **kwargs):
+
+        if action == 'ack':
+            alert.attributes['acked-by'] = g.login
+        if action == 'unack':
+            alert.attributes['acked-by'] = None
+        return alert

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,8 @@ setuptools.setup(
             'remote_ip = alerta.plugins.remote_ip:RemoteIpAddr',
             'reject = alerta.plugins.reject:RejectPolicy',
             'heartbeat = alerta.plugins.heartbeat:HeartbeatReceiver',
-            'blackout = alerta.plugins.blackout:BlackoutHandler'
+            'blackout = alerta.plugins.blackout:BlackoutHandler',
+            'acked_by = alerta.plugins.acked_by:AckedBy'
         ],
         'alerta.webhooks': [
             'cloudwatch = alerta.webhooks.cloudwatch:CloudWatchWebhook',


### PR DESCRIPTION
<img width="1366" alt="Screenshot 2019-05-20 at 02 11 44" src="https://user-images.githubusercontent.com/615057/57990200-a4d29480-7aa4-11e9-9465-b545b28adca8.png">

**Example alertad.conf File**
```
PLUGINS=['reject', 'heartbeat', 'blackout', 'acked_by']
COLUMNS = [
    'severity', 'status', 'lastReceiveTime', 'timeoutLeft', 'duplicateCount',
    'customer', 'environment', 'service', 'resource', 'event', 'value', 'acked-by'
]
```