### PR TITLE
Only match blackout if non-null rule attribute

### DIFF
--- a/alerta/database/backends/mongodb/base.py
+++ b/alerta/database/backends/mongodb/base.py
@@ -897,198 +897,198 @@ class Backend(Database):
         query['environment'] = alert.environment
         query['$and'] = [{'$or': [
             {
-                'resource': {'$exists': False},
-                'service': {'$exists': False},
-                'event': {'$exists': False},
-                'group': {'$exists': False},
-                'tags': {'$exists': False}
+                'resource': None,
+                'service': None,
+                'event': None,
+                'group': None,
+                'tags': None
             },
             {
-                'resource': {'$exists': False},
-                'service': {'$exists': False},
-                'event': {'$exists': False},
-                'group': {'$exists': False},
+                'resource': None,
+                'service': None,
+                'event': None,
+                'group': None,
                 'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
             },
             {
-                'resource': {'$exists': False},
-                'service': {'$exists': False},
-                'event': {'$exists': False},
+                'resource': None,
+                'service': None,
+                'event': None,
                 'group': alert.group,
-                'tags': {'$exists': False}
+                'tags': None
             },
             {
-                'resource': {'$exists': False},
-                'service': {'$exists': False},
-                'event': {'$exists': False},
-                'group': alert.group,
-                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
-            },
-            {
-                'resource': {'$exists': False},
-                'service': {'$exists': False},
-                'event': alert.event,
-                'group': {'$exists': False},
-                'tags': {'$exists': False}
-            },
-            {
-                'resource': {'$exists': False},
-                'service': {'$exists': False},
-                'event': alert.event,
-                'group': {'$exists': False},
-                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
-            },
-            {
-                'resource': {'$exists': False},
-                'service': {'$exists': False},
-                'event': alert.event,
-                'group': alert.group,
-                'tags': {'$exists': False}
-            },
-            {
-                'resource': {'$exists': False},
-                'service': {'$exists': False},
-                'event': alert.event,
+                'resource': None,
+                'service': None,
+                'event': None,
                 'group': alert.group,
                 'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
             },
             {
-                'resource': {'$exists': False},
-                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': {'$exists': False},
-                'group': {'$exists': False},
-                'tags': {'$exists': False}
+                'resource': None,
+                'service': None,
+                'event': alert.event,
+                'group': None,
+                'tags': None
             },
             {
-                'resource': {'$exists': False},
-                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': {'$exists': False},
-                'group': {'$exists': False},
+                'resource': None,
+                'service': None,
+                'event': alert.event,
+                'group': None,
                 'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
             },
             {
-                'resource': {'$exists': False},
-                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': {'$exists': False},
+                'resource': None,
+                'service': None,
+                'event': alert.event,
                 'group': alert.group,
-                'tags': {'$exists': False}
+                'tags': None
             },
             {
-                'resource': {'$exists': False},
-                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': {'$exists': False},
+                'resource': None,
+                'service': None,
+                'event': alert.event,
                 'group': alert.group,
                 'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
             },
             {
-                'resource': {'$exists': False},
+                'resource': None,
                 'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': alert.event,
-                'group': {'$exists': False},
-                'tags': {'$exists': False}
+                'event': None,
+                'group': None,
+                'tags': None
             },
             {
-                'resource': {'$exists': False},
+                'resource': None,
                 'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': alert.event,
-                'group': {'$exists': False},
+                'event': None,
+                'group': None,
                 'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
             },
             {
-                'resource': {'$exists': False},
+                'resource': None,
                 'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': alert.event,
+                'event': None,
                 'group': alert.group,
-                'tags': {'$exists': False}
+                'tags': None
             },
             {
-                'resource': {'$exists': False},
+                'resource': None,
+                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
+                'event': None,
+                'group': alert.group,
+                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
+            },
+            {
+                'resource': None,
+                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
+                'event': alert.event,
+                'group': None,
+                'tags': None
+            },
+            {
+                'resource': None,
+                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
+                'event': alert.event,
+                'group': None,
+                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
+            },
+            {
+                'resource': None,
                 'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
                 'event': alert.event,
                 'group': alert.group,
-                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
+                'tags': None
             },
             {
-                'resource': alert.resource,
-                'service': {'$exists': False},
-                'event': {'$exists': False},
-                'group': {'$exists': False},
-                'tags': {'$exists': False}
-            },
-            {
-                'resource': alert.resource,
-                'service': {'$exists': False},
-                'event': {'$exists': False},
-                'group': {'$exists': False},
-                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
-            },
-            {
-                'resource': alert.resource,
-                'service': {'$exists': False},
-                'event': {'$exists': False},
-                'group': alert.group,
-                'tags': {'$exists': False}
-            },
-            {
-                'resource': alert.resource,
-                'service': {'$exists': False},
-                'event': {'$exists': False},
-                'group': alert.group,
-                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
-            },
-            {
-                'resource': alert.resource,
-                'service': {'$exists': False},
-                'event': alert.event,
-                'group': {'$exists': False},
-                'tags': {'$exists': False}
-            },
-            {
-                'resource': alert.resource,
-                'service': {'$exists': False},
-                'event': alert.event,
-                'group': {'$exists': False},
-                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
-            },
-            {
-                'resource': alert.resource,
-                'service': {'$exists': False},
-                'event': alert.event,
-                'group': alert.group,
-                'tags': {'$exists': False}
-            },
-            {
-                'resource': alert.resource,
-                'service': {'$exists': False},
+                'resource': None,
+                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
                 'event': alert.event,
                 'group': alert.group,
                 'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
             },
             {
                 'resource': alert.resource,
-                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': {'$exists': False},
-                'group': {'$exists': False},
-                'tags': {'$exists': False}
+                'service': None,
+                'event': None,
+                'group': None,
+                'tags': None
             },
             {
                 'resource': alert.resource,
-                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': {'$exists': False},
-                'group': {'$exists': False},
+                'service': None,
+                'event': None,
+                'group': None,
+                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
+            },
+            {
+                'resource': alert.resource,
+                'service': None,
+                'event': None,
+                'group': alert.group,
+                'tags': None
+            },
+            {
+                'resource': alert.resource,
+                'service': None,
+                'event': None,
+                'group': alert.group,
+                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
+            },
+            {
+                'resource': alert.resource,
+                'service': None,
+                'event': alert.event,
+                'group': None,
+                'tags': None
+            },
+            {
+                'resource': alert.resource,
+                'service': None,
+                'event': alert.event,
+                'group': None,
+                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
+            },
+            {
+                'resource': alert.resource,
+                'service': None,
+                'event': alert.event,
+                'group': alert.group,
+                'tags': None
+            },
+            {
+                'resource': alert.resource,
+                'service': None,
+                'event': alert.event,
+                'group': alert.group,
                 'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
             },
             {
                 'resource': alert.resource,
                 'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': {'$exists': False},
-                'group': alert.group,
-                'tags': {'$exists': False}
+                'event': None,
+                'group': None,
+                'tags': None
             },
             {
                 'resource': alert.resource,
                 'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': {'$exists': False},
+                'event': None,
+                'group': None,
+                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
+            },
+            {
+                'resource': alert.resource,
+                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
+                'event': None,
+                'group': alert.group,
+                'tags': None
+            },
+            {
+                'resource': alert.resource,
+                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
+                'event': None,
                 'group': alert.group,
                 'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
             },
@@ -1096,14 +1096,14 @@ class Backend(Database):
                 'resource': alert.resource,
                 'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
                 'event': alert.event,
-                'group': {'$exists': False},
-                'tags': {'$exists': False}
+                'group': None,
+                'tags': None
             },
             {
                 'resource': alert.resource,
                 'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
                 'event': alert.event,
-                'group': {'$exists': False},
+                'group': None,
                 'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
             },
             {
@@ -1111,7 +1111,7 @@ class Backend(Database):
                 'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
                 'event': alert.event,
                 'group': alert.group,
-                'tags': {'$exists': False}
+                'tags': None
             },
             {
                 'resource': alert.resource,

--- a/tests/test_blackouts.py
+++ b/tests/test_blackouts.py
@@ -552,7 +552,7 @@ class BlackoutsTestCase(unittest.TestCase):
             'resource': 'node404',
             'service': ['Network', 'Web'],
             'startTime': '2019-01-01T00:00:00.000Z',
-            'endTime': '2019-12-31T23:59:59.999Z'
+            'endTime': '2049-12-31T23:59:59.999Z'
         }
         response = self.client.post('/blackout', data=json.dumps(blackout), headers=self.headers)
         self.assertEqual(response.status_code, 201)
@@ -560,10 +560,16 @@ class BlackoutsTestCase(unittest.TestCase):
 
         blackout_id = data['id']
 
+        # suppress alert
+        response = self.client.post('/alert', data=json.dumps(self.prod_alert), headers=self.headers)
+        self.assertEqual(response.status_code, 202)
+
         # extend blackout period & change environment
         update = {
             'environment': 'Development',
-            'endTime': '2020-12-31T23:59:59.999Z'
+            'event': None,
+            'tags': [],
+            'endTime': '2099-12-31T23:59:59.999Z'
         }
         response = self.client.put('/blackout/' + blackout_id, data=json.dumps(update), headers=self.headers)
         self.assertEqual(response.status_code, 200)
@@ -579,7 +585,11 @@ class BlackoutsTestCase(unittest.TestCase):
         self.assertEqual(data['blackout']['service'], ['Network', 'Web'])
         self.assertEqual(data['blackout']['group'], None)
         self.assertEqual(data['blackout']['startTime'], '2019-01-01T00:00:00.000Z')
-        self.assertEqual(data['blackout']['endTime'], '2020-12-31T23:59:59.999Z')
+        self.assertEqual(data['blackout']['endTime'], '2099-12-31T23:59:59.999Z')
+
+        # suppress alert
+        response = self.client.post('/alert', data=json.dumps(self.dev_alert), headers=self.headers)
+        self.assertEqual(response.status_code, 202)
 
     def test_user_info(self):
 


### PR DESCRIPTION
Fixes #977 MongoDB only.

>**Equality Filter**
The { name : null } query matches documents that either contain the name field whose value is null or that do not contain the name field.
>
>Given the following query:
>```
>db.users.find( { name: null } )
>```
>The query returns both documents:
>```
>{ "_id" : 900, "name" : null }
>{ "_id" : 901 }
>```
See https://docs.mongodb.com/v3.2/tutorial/query-for-null-fields/