### PR TITLE
Allow LDAP auth with domain/username format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ venv.bak/
 *.swp
 *.BAK
 *.log*
+.vscode

--- a/alerta/auth/basic_ldap.py
+++ b/alerta/auth/basic_ldap.py
@@ -23,10 +23,10 @@ def login():
     except KeyError:
         raise ApiError("must supply 'username' and 'password'", 401)
 
-    email = ''
-    email_verified = False
     if '\\' in login:
         domain, username = login.split('\\')
+        email = ''
+        email_verified = False
     else: 
         username, domain = login.split('@')
         email = login

--- a/alerta/models/user.py
+++ b/alerta/models/user.py
@@ -40,7 +40,10 @@ class User:
     @property
     def domain(self) -> Optional[str]:
         try:
-            return self.email.split('@')[1]
+            if '\\' in self.login:
+                return self.login.split('\\')[0]
+            else:
+                return self.email.split('@')[1]
         except (IndexError, AttributeError):
             return None
 


### PR DESCRIPTION
Adds the ability to login with <domain>\<username> when using the LDAP provider.

I tried to make all the changes in basic_ldap.py but unfortunately I had to edit user.py as well. If this is a sticking point it could be changed so that email login takes precedence, but I can only see it being a problem if somebody has a '\' in their username, which seems unlikely.

