### PR TITLE
Fix authorization logic for OIDC and SAML

### DIFF
--- a/alerta/auth/oidc.py
+++ b/alerta/auth/oidc.py
@@ -142,7 +142,7 @@ def openid():
     if user.status != 'active':
         raise ApiError('User {} is not active'.format(login), 403)
 
-    if not_authorized('ALLOWED_OIDC_ROLES', roles) and not_authorized('ALLOWED_EMAIL_DOMAINS', groups=[user.domain]):
+    if not_authorized('ALLOWED_OIDC_ROLES', roles) or not_authorized('ALLOWED_EMAIL_DOMAINS', groups=[user.domain]):
         raise ApiError('User {} is not authorized'.format(login), 403)
     user.update_last_login()
 

--- a/alerta/auth/saml.py
+++ b/alerta/auth/saml.py
@@ -96,7 +96,7 @@ def saml_response_from_idp():
         raise ApiError('User {} is not active'.format(email), 403)
 
     groups = identity.get('groups', [])
-    if not_authorized('ALLOWED_SAML2_GROUPS', groups) and not_authorized('ALLOWED_EMAIL_DOMAINS', groups=[user.domain]):
+    if not_authorized('ALLOWED_SAML2_GROUPS', groups) or not_authorized('ALLOWED_EMAIL_DOMAINS', groups=[user.domain]):
         message = {'status': 'error', 'message': 'User {} is not authorized'.format(email)}
         return render_template('auth/saml2.html', message=message, origin=origin), 403
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -721,7 +721,7 @@ class AuthProvidersTestCase(unittest.TestCase):
             'AUTH_PROVIDER': 'gitlab',
             # 'OIDC_ISSUER_URL': 'https://gitlab.com',
             # 'OIDC_CUSTOM_CLAIM': 'groups',
-            'ALLOWED_OIDC_ROLES': ['alerta-project'],
+            'ALLOWED_GITLAB_GROUPS': ['alerta-project'],
             'CUSTOMER_VIEWS': True,
         }
 
@@ -1241,6 +1241,7 @@ class AuthProvidersTestCase(unittest.TestCase):
           "roles": [
             "create-realm",
             "devops",
+            "alerta-project",
             "admin"
           ],
           "name": "Nicholas Satterly",
@@ -1290,7 +1291,7 @@ class AuthProvidersTestCase(unittest.TestCase):
         self.assertEqual(claims['name'], 'Nicholas Satterly', claims)
         self.assertEqual(claims['preferred_username'], 'nsatterl', claims)
         self.assertEqual(claims['provider'], 'keycloak', claims)
-        self.assertEqual(claims['roles'], ['create-realm', 'devops', 'admin'], claims)
+        self.assertEqual(claims['roles'], ['create-realm', 'devops', 'alerta-project', 'admin'], claims)
         self.assertEqual(claims['scope'], 'read write', claims)
         self.assertEqual(claims['email'], 'nick@alerta.dev', claims)
         self.assertEqual(claims.get('email_verified'), True, claims)


### PR DESCRIPTION
See #1009

Changes logic for oidc and saml authorization checks so that
the authorization fails if either of the authorization checks
fail.