### PR TITLE
Allowing for configurable SAML metadata and string casting Descriptor 

### DIFF
--- a/alerta/auth/saml.py
+++ b/alerta/auth/saml.py
@@ -47,6 +47,9 @@ def get_saml2_config():
     if current_app.config['SAML2_ENTITY_ID']:
         saml_settings['entityid'] = current_app.config['SAML2_ENTITY_ID']
 
+    if current_app.config['SAML2_CONFIG'].get('metadata'):
+        saml_settings['metadata'] = current_app.config['SAML2_CONFIG']['metadata']
+
     merge(saml_settings, current_app.config['SAML2_CONFIG'])  # allow settings override
 
     config.load(saml_settings)
@@ -119,4 +122,4 @@ def saml_response_from_idp():
 @auth.route('/auth/saml/metadata.xml', methods=['GET'])
 def saml_metadata():
     descriptor = saml2.metadata.entity_descriptor(get_saml2_config())
-    return Response(descriptor, content_type='text/xml; charset=utf-8')
+    return Response(str(descriptor), content_type='text/xml; charset=utf-8')


### PR DESCRIPTION
after migrating from 6.8 alerta to 7.2.11 , SAML authentication broke for us for with 2 issues :

1.  the default "saml_settings" in saml.py assumes the metadata is a "remote" url while our configuration uses a local idp.xml metadata 
```
SAML2_CONFIG = {
    'metadata': {
        'local': ['/etc/idp.xml']
    },
    'allow_unknown_attributes': True,
    'organization': {
        'name': [('orgainization','en')],
        'display_name': ['orgainization'],
        "url": [("https://alerta.com","en")],
    },
    "service": {
        "sp": {
            "allow_unsolicited": True,
        }
    },
    'key_file': '/etc/alerta_saml.key',
    'cert_file': '/etc/alerta_saml.cert'
}
```

2. ( after fixing issue 1 by overwriting the default metadata ) when accessing the endpoint /auth/saml/metadata.xml the following error is shown "EntityDescriptor  object is not iterable", it simply needed a string casting