### PR TITLE
Allow LDAP servers to use a self signed certificate

### DIFF
--- a/alerta/auth/basic_ldap.py
+++ b/alerta/auth/basic_ldap.py
@@ -17,7 +17,7 @@ from . import auth
 @cross_origin(supports_credentials=True)
 def login():
     # Allow LDAP server to use a self signed certificate
-    if current_app.config['LDAP_TLS_ALLOW_SELFSIGNED']:
+    if current_app.config['LDAP_ALLOW_SELF_SIGNED_CERT']:
         ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_ALLOW)
 
     # Retrieve required fields from client request

--- a/alerta/auth/basic_ldap.py
+++ b/alerta/auth/basic_ldap.py
@@ -16,6 +16,10 @@ from . import auth
 @auth.route('/auth/login', methods=['OPTIONS', 'POST'])
 @cross_origin(supports_credentials=True)
 def login():
+    # Allow LDAP server to use a self signed certificate
+    if current_app.config['LDAP_TLS_ALLOW_SELFSIGNED']:
+        ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_ALLOW)
+
     # Retrieve required fields from client request
     try:
         login = request.json.get('username', None) or request.json['email']

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -87,7 +87,7 @@ LDAP_URL = ''  # eg. ldap://localhost:389
 LDAP_DOMAINS = {}  # type: Dict[str, str]
 LDAP_DOMAINS_GROUP = {}  # type: Dict[str, str]
 LDAP_DOMAINS_BASEDN = {}  # type: Dict[str, str]
-LDAP_TLS_ALLOW_SELFSIGNED = False
+LDAP_ALLOW_SELF_SIGNED_CERT = False
 
 # Microsoft Identity Platform (v2.0)
 AZURE_TENANT = 'common'  # "common", "organizations", "consumers" or tenant ID

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -87,6 +87,7 @@ LDAP_URL = ''  # eg. ldap://localhost:389
 LDAP_DOMAINS = {}  # type: Dict[str, str]
 LDAP_DOMAINS_GROUP = {}  # type: Dict[str, str]
 LDAP_DOMAINS_BASEDN = {}  # type: Dict[str, str]
+LDAP_TLS_ALLOW_SELFSIGNED = False
 
 # Microsoft Identity Platform (v2.0)
 AZURE_TENANT = 'common'  # "common", "organizations", "consumers" or tenant ID

--- a/alerta/utils/config.py
+++ b/alerta/utils/config.py
@@ -88,6 +88,9 @@ class Config:
         if 'ALLOWED_GITLAB_GROUPS' in os.environ:
             config['ALLOWED_OIDC_ROLES'] = os.environ['ALLOWED_GITLAB_GROUPS'].split(',')
 
+        if 'LDAP_TLS_ALLOW_SELFSIGNED' in os.environ:
+            config['LDAP_TLS_ALLOW_SELFSIGNED'] = True if os.environ['LDAP_TLS_ALLOW_SELFSIGNED'] == 'True' else False
+
         if 'KEYCLOAK_URL' in os.environ:
             config['KEYCLOAK_URL'] = os.environ['KEYCLOAK_URL']
 

--- a/alerta/utils/config.py
+++ b/alerta/utils/config.py
@@ -88,9 +88,6 @@ class Config:
         if 'ALLOWED_GITLAB_GROUPS' in os.environ:
             config['ALLOWED_OIDC_ROLES'] = os.environ['ALLOWED_GITLAB_GROUPS'].split(',')
 
-        if 'LDAP_TLS_ALLOW_SELFSIGNED' in os.environ:
-            config['LDAP_TLS_ALLOW_SELFSIGNED'] = True if os.environ['LDAP_TLS_ALLOW_SELFSIGNED'] == 'True' else False
-
         if 'KEYCLOAK_URL' in os.environ:
             config['KEYCLOAK_URL'] = os.environ['KEYCLOAK_URL']
 


### PR DESCRIPTION
Sometimes internal LDAP servers will use a self signed certificate. By default python-ldap will connections to LDAP servers with a self signed certificate. 

This allow the configuration of the python-ldap setting via Alertas configuration.