### PR TITLE
telegram webhook: return error if alert_id is not found.

### DIFF
--- a/alerta/webhooks/telegram.py
+++ b/alerta/webhooks/telegram.py
@@ -76,10 +76,10 @@ class TelegramWebhook(WebhookBase):
 
             customers = g.get('customers', None)
             alert = Alert.find_by_id(alert_id, customers=customers)
-            if not alert:
-                jsonify(status='error', message='alert not found for Telegram message')
-
             action = command.lstrip('/')
+            if not alert and action != 'blackout':
+                return jsonify(status='error', message='alert not found for Telegram message')
+
             if action in ['open', 'ack', 'close']:
                 alert.set_status(status=action, text='status change via Telegram')
             elif action in ['watch', 'unwatch']:

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -825,6 +825,13 @@ class WebhooksTestCase(unittest.TestCase):
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(data['status'], 'ok')
 
+        # command=/ack with bogus telegram_alert_id
+        response = self.client.post('/webhooks/telegram', data=self.telegram_ack %
+                                    'bogus-id-this-shouldnt-exist', headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['status'], 'error')
+
     def test_custom_webhook(self):
 
         # setup custom webhook


### PR DESCRIPTION
return error if Alert.find_by_id doesn't find alert_id (otherwise alert.set_status / alert.untag fail: 'NoneType' object has no attribute 'set_status').
(Discussed in https://github.com/alerta/alerta-contrib/issues/289).

(Note: I didn't test the bogus-id-this-shouldnt-exist test, I hope the test works / is ok).