### PR TITLE
X-API-Key and Authorization: Bearer headers.

### DIFF
--- a/alerta/auth/decorators.py
+++ b/alerta/auth/decorators.py
@@ -24,7 +24,7 @@ def permission(scope=None):
         def wrapped(*args, **kwargs):
 
             # API Key (Authorization: Key <key>)
-            if 'Authorization' in request.headers:
+            if 'Authorization' in request.headers and request.headers['Authorization'].find('Key ', 0, 4) == 0:
                 auth_header = request.headers['Authorization']
                 m = re.match(r'Key (\S+)', auth_header)
                 key = m.group(1) if m else None

--- a/alerta/auth/decorators.py
+++ b/alerta/auth/decorators.py
@@ -24,7 +24,7 @@ def permission(scope=None):
         def wrapped(*args, **kwargs):
 
             # API Key (Authorization: Key <key>)
-            if 'Authorization' in request.headers and request.headers['Authorization'].find('Key ', 0, 4) == 0:
+            if 'Authorization' in request.headers and request.headers['Authorization'].startswith('Key '):
                 auth_header = request.headers['Authorization']
                 m = re.match(r'Key (\S+)', auth_header)
                 key = m.group(1) if m else None


### PR DESCRIPTION
To use X-API-Key header with msteams(webhook) we need to look for X-API-Key if Authorization header doesn't have key.
(this was briefly discussed in https://github.com/alerta/alerta-contrib/issues/280)

(Note: Changing L32 to if not key ... doesn't work, because if request has valid Authorization: Key then L35/36 (else block) always overwrites key variable).
