### PR TITLE
Allow Action "Timeout" to be manipulated by Plugin

### DIFF
--- a/alerta/plugins/__init__.py
+++ b/alerta/plugins/__init__.py
@@ -37,7 +37,7 @@ class PluginBase:
         """Trigger integrations based on status changes."""
         raise NotImplementedError
 
-    def take_action(self, alert: 'Alert', action: str, text: str, **kwargs) -> Any:
+    def take_action(self, alert: 'Alert', action: str, text: str, timeout: int, **kwargs) -> Any:
         """Trigger integrations based on external actions. (optional)"""
         raise NotImplementedError
 

--- a/alerta/tasks.py
+++ b/alerta/tasks.py
@@ -17,7 +17,7 @@ def action_alerts(alerts: List[str], action: str, text: str, timeout: int) -> No
 
         try:
             previous_status = alert.status
-            alert, action, text = process_action(alert, action, text)
+            alert, action, text, timeout = process_action(alert, action, text, timeout)
             alert = alert.from_action(action, text, timeout)
         except RejectException as e:
             errors.append(str(e))

--- a/alerta/utils/api.py
+++ b/alerta/utils/api.py
@@ -99,7 +99,7 @@ def process_action(alert: Alert, action: str, text: str, timeout: int) -> Tuple[
         try:
             updated = plugin.take_action(alert, action, text, timeout, config=wanted_config)
         except TypeError:
-            updated_bc = plugin.take_action(alert, status, text, config=wanted_config)  # for backward compatibility
+            updated_bc = plugin.take_action(alert, action, text, config=wanted_config)  # for backward compatibility
         except NotImplementedError:
             pass  # plugin does not support action() method
         except RejectException:

--- a/alerta/utils/api.py
+++ b/alerta/utils/api.py
@@ -111,7 +111,7 @@ def process_action(alert: Alert, action: str, text: str, timeout: int) -> Tuple[
                 logging.error("Error while running action plugin '{}': {}".format(plugin.name, str(e)))
         if updated:
             try:
-                if updatedBc != None:
+                if updated_bc != None:
                     alert, action, text = updated_bc #for backward compatibility
                 else:
                     alert, action, text, timeout = updated

--- a/alerta/utils/api.py
+++ b/alerta/utils/api.py
@@ -87,7 +87,7 @@ def process_alert(alert: Alert) -> Alert:
     return alert
 
 
-def process_action(alert: Alert, action: str, text: str, timeout: int) -> Tuple[Alert, str, str]:
+def process_action(alert: Alert, action: str, text: str, timeout: int) -> Tuple[Alert, str, str, int]:
 
     wanted_plugins, wanted_config = plugins.routing(alert)
 

--- a/alerta/views/alerts.py
+++ b/alerta/views/alerts.py
@@ -149,7 +149,7 @@ def action_alert(alert_id):
         raise ApiError('not found', 404)
 
     try:
-        alert, action, text = process_action(alert, action, text)
+        alert, action, text, timeout = process_action(alert, action, text, timeout)
         alert = alert.from_action(action, text, timeout)
     except RejectException as e:
         write_audit_trail.send(current_app._get_current_object(), event='alert-action-rejected', message=alert.text,


### PR DESCRIPTION
Hello.  I needed the ability to manipulate the timeout when shelving alerts to be dynamically configurable (by plugin) so that I can shelve the alerts for different duration based on the specifics of the alert.

Currently, the only timeout variable allowed came from the UI through user preferences.

This change adds timeout as a parameter to the process_action method and plugin.take_action method.  I added a new variable to track for backwards incompatibility in the process_action method.

I hope this is sufficient.