### PR TITLE
Pass timeout to action process_action and take_action functions

### DIFF
--- a/alerta/tasks.py
+++ b/alerta/tasks.py
@@ -17,7 +17,7 @@ def action_alerts(alerts: List[str], action: str, text: str, timeout: int) -> No
 
         try:
             previous_status = alert.status
-            alert, action, text = process_action(alert, action, text)
+            alert, action, text, timeout = process_action(alert, action, text, timeout)
             alert = alert.from_action(action, text, timeout)
         except RejectException as e:
             errors.append(str(e))

--- a/alerta/utils/api.py
+++ b/alerta/utils/api.py
@@ -108,8 +108,8 @@ def process_action(alert: Alert, action: str, text: str, timeout: int) -> Tuple[
         if updated:
             try:
                 if len(updated) == 3:
-                    alert, action, text = updated   
-                elif len(updated) == 4: 
+                    alert, action, text = updated
+                elif len(updated) == 4:
                     alert, action, text, timeout = updated
                 else:
                     alert = updated

--- a/alerta/utils/api.py
+++ b/alerta/utils/api.py
@@ -107,12 +107,14 @@ def process_action(alert: Alert, action: str, text: str, timeout: int) -> Tuple[
                 logging.error("Error while running action plugin '{}': {}".format(plugin.name, str(e)))
         if updated:
             try:
-                try:
-                    alert, action, text = updated    #if timeout does not get returned, try default behavior
-                except Exception:
-                    alert, action, text, timeout = updated #Try to see if timeout gets returned
+                if len(updated) == 3:
+                    alert, action, text = updated   
+                elif len(updated) == 4: 
+                    alert, action, text, timeout = updated
+                else:
+                    alert = updated
             except Exception:
-                alert = updated
+                logging.error("Error while running action plugin '{}': {}".format(plugin.name, str(e)))
 
     # remove keys from attributes with None values
     new_attrs = {k: v for k, v in alert.attributes.items() if v is not None}

--- a/alerta/utils/api.py
+++ b/alerta/utils/api.py
@@ -109,9 +109,9 @@ def process_action(alert: Alert, action: str, text: str, time_out: int) -> Tuple
         if updated:
             try:
                 try:
-                    alert, action, text, time_out = updated #Try to see if timeout gets returned
-                except Exception:
                     alert, action, text = updated    #if timeout does not get returned, try default behavior
+                except Exception:
+                    alert, action, text, time_out = updated #Try to see if timeout gets returned
             except Exception:
                 alert = updated
 

--- a/alerta/utils/api.py
+++ b/alerta/utils/api.py
@@ -87,8 +87,7 @@ def process_alert(alert: Alert) -> Alert:
     return alert
 
 
-def process_action(alert: Alert, action: str, text: str, time_out: int) -> Tuple[Alert, str, str, int]:
-    #named variable time_out so doesnt conflict with kwargs name
+def process_action(alert: Alert, action: str, text: str, timeout: int) -> Tuple[Alert, str, str, int]:
     wanted_plugins, wanted_config = plugins.routing(alert)
 
     updated = None
@@ -96,7 +95,7 @@ def process_action(alert: Alert, action: str, text: str, time_out: int) -> Tuple
         if alert.is_suppressed:
             break
         try:
-            updated = plugin.take_action(alert, action, text, config=wanted_config, timeout=time_out)
+            updated = plugin.take_action(alert, action, text, timeout=timeout, config=wanted_config)
         except NotImplementedError:
             pass  # plugin does not support action() method
         except RejectException:
@@ -111,7 +110,7 @@ def process_action(alert: Alert, action: str, text: str, time_out: int) -> Tuple
                 try:
                     alert, action, text = updated    #if timeout does not get returned, try default behavior
                 except Exception:
-                    alert, action, text, time_out = updated #Try to see if timeout gets returned
+                    alert, action, text, timeout = updated #Try to see if timeout gets returned
             except Exception:
                 alert = updated
 
@@ -119,7 +118,7 @@ def process_action(alert: Alert, action: str, text: str, time_out: int) -> Tuple
     new_attrs = {k: v for k, v in alert.attributes.items() if v is not None}
     alert.attributes = new_attrs
 
-    return alert, action, text, time_out
+    return alert, action, text, timeout
 
 
 def process_status(alert: Alert, status: str, text: str) -> Tuple[Alert, str, str]:

--- a/alerta/utils/api.py
+++ b/alerta/utils/api.py
@@ -113,7 +113,7 @@ def process_action(alert: Alert, action: str, text: str, timeout: int) -> Tuple[
                     alert, action, text, timeout = updated
                 else:
                     alert = updated
-            except Exception:
+            except Exception as e:
                 logging.error("Error while running action plugin '{}': {}".format(plugin.name, str(e)))
 
     # remove keys from attributes with None values

--- a/alerta/views/alerts.py
+++ b/alerta/views/alerts.py
@@ -149,7 +149,7 @@ def action_alert(alert_id):
         raise ApiError('not found', 404)
 
     try:
-        alert, action, text = process_action(alert, action, text)
+        alert, action, text, timeout = process_action(alert, action, text, timeout)
         alert = alert.from_action(action, text, timeout)
     except RejectException as e:
         write_audit_trail.send(current_app._get_current_object(), event='alert-action-rejected', message=alert.text,


### PR DESCRIPTION
added kwarg for timeout for process_action so it can be used in a plugin during the take_action phase.

The need is to be able to use a plugin to change the timeout value based on the attributes of the alerts.  Currently the timeout value needs to be set upon the initial call to the API but we need an ability to overwrite that using a plugin, especially when trying to use the UI.