### PR TITLE
Bump psycopg2 to v2.8.3, use psycopg2-binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cryptography==2.6.1
 Flask==1.0.2
 Flask-Compress==1.4.0
 Flask-Cors==3.0.7
-psycopg2==2.8.1
+psycopg2-binary==2.8.3
 PyJWT==1.7.1
 pymongo==3.7.2
 pyparsing==2.4.0


### PR DESCRIPTION
When trying to run `make init` on MacOS, installing psycopg2 fails because of missing binaries.
```
ollecting psycopg2==2.8.1 (from -r requirements.txt (line 6))
  Downloading https://files.pythonhosted.org/packages/52/be/f898e712f5f08131d651a62754fca82a1deb42e4e9889ad01932f770a2be/psycopg2-2.8.1.tar.gz (367kB)
    100% |████████████████████████████████| 368kB 23.4MB/s
    Complete output from command python setup.py egg_info:
    running egg_info
    creating pip-egg-info/psycopg2.egg-info
    writing pip-egg-info/psycopg2.egg-info/PKG-INFO
    writing dependency_links to pip-egg-info/psycopg2.egg-info/dependency_links.txt
    writing top-level names to pip-egg-info/psycopg2.egg-info/top_level.txt
    writing manifest file 'pip-egg-info/psycopg2.egg-info/SOURCES.txt'

    Error: pg_config executable not found.

    pg_config is required to build psycopg2 from source.  Please add the directory
    containing pg_config to the $PATH or specify the full executable path with the
    option:

        python setup.py build_ext --pg-config /path/to/pg_config build ...

    or with the pg_config option in 'setup.cfg'.

    If you prefer to avoid building psycopg2 from source, please install the PyPI
    'psycopg2-binary' package instead.

    For further information please check the 'doc/src/install.rst' file (also at
    <http://initd.org/psycopg/docs/install.html>).
```

more context: http://initd.org/psycopg/docs/install.html#binary-install-from-pypi