### PR TITLE
Bump versions on pre-commit checks.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     -   id: autopep8
 -   repo: https://github.com/pre-commit/pre-commit-hooks.git
-    rev: v2.2.1
+    rev: v2.2.3
     hooks:
     -   id: check-added-large-files
     -   id: check-ast
@@ -27,15 +27,15 @@ repos:
     -   id: requirements-txt-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v1.16.3
+    rev: v1.22.0
     hooks:
     -   id: pyupgrade
         args: ['--py3-plus']
 -   repo: https://github.com/asottile/seed-isort-config
-    rev: v1.9.0
+    rev: v1.9.2
     hooks:
     -   id: seed-isort-config
 -   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.18
+    rev: v4.3.21
     hooks:
     -   id: isort


### PR DESCRIPTION
Those bumps happened "automatically" when pre-commit ran locally, so I figured I'll push this update.