### PR TITLE
Add Python 3.7 to classifiers since it is also supported

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setuptools.setup(
         'Intended Audience :: System Administrators',
         'Intended Audience :: Telecommunications Industry',
         'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.5',
         'Topic :: System :: Monitoring',


### PR DESCRIPTION
As far as I can tell, based on the travis config.