### PR TITLE
Mark regex strings as raw strings, properly escape strings

### DIFF
--- a/alerta/database/backends/mongodb/queryparser.py
+++ b/alerta/database/backends/mongodb/queryparser.py
@@ -138,7 +138,7 @@ clause = Forward()
 field_name = valid_word()('fieldname')
 single_term = valid_word()('singleterm')
 phrase = QuotedString('"', unquoteResults=True)('phrase')
-wildcard = Regex('[a-z0-9]*[\?\*][a-z0-9]*')('wildcard')
+wildcard = Regex(r'[a-z0-9]*[\?\*][a-z0-9]*')('wildcard')
 wildcard.setParseAction(
     lambda t: t[0].replace('?', '.?').replace('*', '.*')
 )

--- a/alerta/database/backends/postgres/queryparser.py
+++ b/alerta/database/backends/postgres/queryparser.py
@@ -127,7 +127,7 @@ clause = Forward()
 field_name = valid_word()('fieldname')
 single_term = valid_word()('singleterm')
 phrase = QuotedString('"', unquoteResults=True)('phrase')
-wildcard = Regex('[a-z0-9]*[\?\*][a-z0-9]*')('wildcard')
+wildcard = Regex(r'[a-z0-9]*[\?\*][a-z0-9]*')('wildcard')
 wildcard.setParseAction(
     lambda t: t[0].replace('?', '.?').replace('*', '.*')
 )

--- a/tests/test_queryparser.py
+++ b/tests/test_queryparser.py
@@ -22,7 +22,7 @@ class PostgresQueryTestCase(unittest.TestCase):
         # default field (ie. "text") contains phrase
         string = r'''"quick brown"'''
         r = self.parser.parse(string)
-        self.assertEqual(r, '"text" ~* \'\yquick brown\y\'')
+        self.assertEqual(r, '"text" ~* \'\\yquick brown\\y\'')
 
     def test_field_names(self):
 
@@ -44,7 +44,7 @@ class PostgresQueryTestCase(unittest.TestCase):
         # field exact match
         string = r'''author:"John Smith"'''
         r = self.parser.parse(string)
-        self.assertEqual(r, '"author" ~* \'\yJohn Smith\y\'')
+        self.assertEqual(r, '"author" ~* \'\\yJohn Smith\\y\'')
 
         # # any attribute contains word or phrase
         # string = r'''attributes.\*:(quick brown)'''
@@ -61,7 +61,7 @@ class PostgresQueryTestCase(unittest.TestCase):
         # ? = single character, * = one or more characters
         string = r'''text:qu?ck bro*'''
         r = self.parser.parse(string)
-        self.assertEqual(r, '("text" ~* \'\yqu.?ck\y\' OR "text" ~* \'\ybro.*\y\')')
+        self.assertEqual(r, '("text" ~* \'\\yqu.?ck\\y\' OR "text" ~* \'\\ybro.*\\y\')')
 
     def test_regular_expressions(self):
 


### PR DESCRIPTION
See https://lintlyci.github.io/Flake8Rules/rules/W605.html
from https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior:
>A backslash-character pair that is not a valid escape sequence now generates a DeprecationWarning. Although this will eventually become a SyntaxError, that will not be for several Python releases. (Contributed by Emanuel Barry in bpo-27364.)

Those strings cause deprecation warnings when running under python 3.6, flake 8 also complains about them:
<img width="657" alt="Screenshot 2019-08-05 06 29 41" src="https://user-images.githubusercontent.com/1268088/62468373-c3166b00-b74a-11e9-8c6d-b52b83b78559.png">