### PR TITLE
Raven is deprecated, switch to sentry-sdk

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = blinker,bson,click,dateutil,flask,flask_compress,flask_cors,itsdangerous,jwt,ldap,pkg_resources,psycopg2,pymongo,pyparsing,pytz,raven,requests,requests_mock,saml2,setuptools,werkzeug,yaml
+known_third_party = blinker,bson,click,dateutil,flask,flask_compress,flask_cors,itsdangerous,jwt,ldap,pkg_resources,psycopg2,pymongo,pyparsing,pytz,requests,requests_mock,saml2,sentry_sdk,setuptools,werkzeug,yaml

--- a/alerta/app.py
+++ b/alerta/app.py
@@ -35,7 +35,7 @@ key_helper = ApiKeyHelper()
 db = Database()
 qb = QueryBuilder()
 # Sentry will grab DSN from SENTRY_DSN environment variable.
-sentry_sdk.init(None, integrations=[FlaskIntegration()])
+sentry_sdk.init(integrations=[FlaskIntegration()])
 
 mailer = Mailer()
 plugins = Plugins()

--- a/alerta/app.py
+++ b/alerta/app.py
@@ -1,9 +1,10 @@
 from typing import Any, Dict
 
+import sentry_sdk
 from flask import Flask
 from flask_compress import Compress
 from flask_cors import CORS
-from raven.contrib.flask import Sentry
+from sentry_sdk.integrations.flask import FlaskIntegration
 from werkzeug.contrib.fixers import ProxyFix
 
 from alerta.database.base import Database, QueryBuilder
@@ -33,13 +34,15 @@ key_helper = ApiKeyHelper()
 
 db = Database()
 qb = QueryBuilder()
-sentry = Sentry()
+# Sentry will grab DSN from SENTRY_DSN environment variable.
+sentry_sdk.init(None, integrations=[FlaskIntegration()])
+
 mailer = Mailer()
 plugins = Plugins()
 custom_webhooks = CustomWebhooks()
 
 
-def create_app(config_override: Dict[str, Any]=None, environment: str=None) -> Flask:
+def create_app(config_override: Dict[str, Any] = None, environment: str = None) -> Flask:
 
     app = Flask(__name__)
     app.config['ENVIRONMENT'] = environment
@@ -63,7 +66,6 @@ def create_app(config_override: Dict[str, Any]=None, environment: str=None) -> F
 
     db.init_db(app)
     qb.init_app(app)
-    sentry.init_app(app)
 
     mailer.register(app)
     plugins.register(app)
@@ -94,7 +96,7 @@ except ImportError:
     pass
 
 
-def create_celery_app(app: Flask=None) -> 'Celery':
+def create_celery_app(app: Flask = None) -> 'Celery':
 
     from alerta.utils.format import register_custom_serializer
     register_custom_serializer()

--- a/alerta/webhooks/custom.py
+++ b/alerta/webhooks/custom.py
@@ -24,7 +24,7 @@ def custom(webhook):
     try:
         rv = custom_webhooks.webhooks[webhook].incoming(
             query_string=request.args,
-            payload=request.get_json() or request.get_data(as_text=True) or request.form
+            payload=request.get_json() or request.form or request.get_data(as_text=True)
         )
     except Exception as e:
         raise ApiError(str(e), 400)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ pyparsing==2.4.0
 python-dateutil==2.8.0
 pytz==2019.1
 PyYAML==5.1
-raven==6.10.0
 requests==2.21.0
+sentry-sdk[flask]===0.10.2

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
         'Flask>=0.10.1',
         'Flask-Cors>=3.0.2',
         'Flask-Compress>=1.4.0',
-        'raven[flask]>=6.2.1',
+        'sentry-sdk[flask]>=0.10.2',
         'pymongo>=3.0',
         'pyparsing',
         'requests',


### PR DESCRIPTION
instead of https://github.com/alerta/alerta/pull/1054:
https://github.com/getsentry/raven-python#raven---sentry-for-python

>This SDK is being phased out for Sentry-Python.

https://docs.sentry.io/platforms/python/flask/

------------



The change in the custom webhook code: when debugging the previous [test failure](https://travis-ci.org/alerta/alerta/jobs/570122094) I noticed that when running with the new sentry sdk calling get_data hits a different code path:
https://github.com/pallets/werkzeug/blob/f753a326343cf5d163720f0d954d62aba3c5618c/src/werkzeug/wrappers/base_request.py#L451 
the `_cached_data` is populated (with `'say=Hi&to=Mom'`) and so this one takes, and that is the string that ends up getting passed to payload (to the webhook.incoming method)
with the old version (raven) get_data() returns an empty string and so we call request.form and that one returns the required result.
By looking at the sentry-sdk source code, you can see that the flask integration calls call of those methods to try and collect as much data on the request in case of an error, which causes _cached_data to be populated.
I have run this change (w/o the sentry upgrade) and all the tests seem to pass.
Moreover, it seems that we should prefer structured data (form) before resorting to raw data (string)