### PR TITLE
Switch to using pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ install:
 script:
   - python -m mypy alerta/
   - pre-commit run -a
-  - nosetests --verbosity=3 tests/*
+  - pytest --cov=alerta

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ clean:
 	rm -Rf build dist *.egg-info
 
 test:
-	ALERTA_SVR_CONF_FILE= nosetests tests
+	ALERTA_SVR_CONF_FILE= pytest
 
 run:
 	alertad run --port 8080 --with-threads --reload

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ To run the tests using a local Postgres database run:
     $ pip install -r requirements.txt
     $ pip install -e .[postgres]
     $ createdb test5
-    $ ALERTA_SVR_CONF_FILE= DATABASE_URL=postgres:///test5 nosetests
+    $ ALERTA_SVR_CONF_FILE= DATABASE_URL=postgres:///test5 pytest
 
 Cloud Deployment
 ----------------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 mypy==0.620
-nose
 pre-commit
+pytest
+pytest-cov
 python-dotenv
 requests_mock
 twine


### PR DESCRIPTION
nose is [effectively dead](https://nose.readthedocs.io/en/latest/#note-to-users) and even [nose2 docs](https://github.com/nose-devs/nose2#nose2-vs-pytest) says to use pytest
so I think it is a good idea to switch to using pytest