### PR TITLE
Add coveralls - code coverage service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ install:
   - pip install .
 
 script:
+  - pip install coveralls
   - python -m mypy alerta/
   - pre-commit run -a
   - pytest --cov=alerta
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Alerta Release 7.0
 
 [![Build Status](https://travis-ci.org/alerta/alerta.png)](https://travis-ci.org/alerta/alerta)
 [![Gitter chat](https://badges.gitter.im/alerta/chat.png)](https://gitter.im/alerta/chat)
+[![Coverage Status](https://coveralls.io/repos/github/alerta/alerta/badge.svg?branch=master)](https://coveralls.io/github/alerta/alerta?branch=master)
 
 The Alerta monitoring tool was developed with the following aims in mind:
 


### PR DESCRIPTION
You will need to create a [coveralls](https://github.com/marketplace/coveralls) account (free for open source) and add the repo to coveralls.
then add the repo token to [travis](https://travis-ci.org/alerta/alerta/settings)
<img width="1154" alt="Screenshot 2019-08-13 09 14 56" src="https://user-images.githubusercontent.com/1268088/62958340-597e0880-bdab-11e9-8dfa-fe007507af0c.png">

Feel free to ping me in gitter, I am in the alerta chat there.