### PR TITLE
Fix pytest warnings.

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -25,7 +25,7 @@ class LoggingTestCase(unittest.TestCase):
     def test_custom_webhook(self):
 
         # setup custom webhook
-        custom_webhooks.webhooks['json'] = TestJsonWebhook()
+        custom_webhooks.webhooks['json'] = DummyJsonWebhook()
 
         payload = """
             {"baz": "quux %X %%"}
@@ -39,7 +39,7 @@ class LoggingTestCase(unittest.TestCase):
         self.assertEqual(data['alert']['event'], 'quux %X %%')
 
 
-class TestJsonWebhook(WebhookBase):
+class DummyJsonWebhook(WebhookBase):
 
     def incoming(self, query_string, payload):
         return Alert(

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -835,11 +835,11 @@ class WebhooksTestCase(unittest.TestCase):
     def test_custom_webhook(self):
 
         # setup custom webhook
-        custom_webhooks.webhooks['json'] = TestJsonWebhook()
-        custom_webhooks.webhooks['text'] = TestTextWebhook()
-        custom_webhooks.webhooks['form'] = TestFormWebhook()
-        custom_webhooks.webhooks['multipart'] = TestMultiPartFormWebhook()
-        custom_webhooks.webhooks['userdefined'] = TestUserDefinedWebhook()
+        custom_webhooks.webhooks['json'] = DummyJsonWebhook()
+        custom_webhooks.webhooks['text'] = DummyTextWebhook()
+        custom_webhooks.webhooks['form'] = DummyFormWebhook()
+        custom_webhooks.webhooks['multipart'] = DummyMultiPartFormWebhook()
+        custom_webhooks.webhooks['userdefined'] = DummyUserDefinedWebhook()
 
         # test json payload
         response = self.client.post('/webhooks/json?foo=bar', json={'baz': 'quux'}, content_type='application/json')
@@ -885,7 +885,7 @@ class WebhooksTestCase(unittest.TestCase):
         self.assertEqual(data['teapot'], True)
 
 
-class TestJsonWebhook(WebhookBase):
+class DummyJsonWebhook(WebhookBase):
 
     def incoming(self, query_string, payload):
         return Alert(
@@ -896,7 +896,7 @@ class TestJsonWebhook(WebhookBase):
         )
 
 
-class TestTextWebhook(WebhookBase):
+class DummyTextWebhook(WebhookBase):
 
     def incoming(self, query_string, payload):
         return Alert(
@@ -907,7 +907,7 @@ class TestTextWebhook(WebhookBase):
         )
 
 
-class TestFormWebhook(WebhookBase):
+class DummyFormWebhook(WebhookBase):
 
     def incoming(self, query_string, payload):
         return Alert(
@@ -918,7 +918,7 @@ class TestFormWebhook(WebhookBase):
         )
 
 
-class TestMultiPartFormWebhook(WebhookBase):
+class DummyMultiPartFormWebhook(WebhookBase):
 
     def incoming(self, query_string, payload):
         return Alert(
@@ -929,7 +929,7 @@ class TestMultiPartFormWebhook(WebhookBase):
         )
 
 
-class TestUserDefinedWebhook(WebhookBase):
+class DummyUserDefinedWebhook(WebhookBase):
 
     def incoming(self, query_string, payload):
         return jsonify(


### PR DESCRIPTION
pytest thinks that every class that beings with "Test" contains unit tests and emits warnings about it:
```
tests/test_logging.py:42
  /home/travis/build/alerta/alerta/tests/test_logging.py:42: PytestWarning: cannot collect test class 'TestJsonWebhook' because it has a __init__ constructor
    class TestJsonWebhook(WebhookBase):
tests/test_webhooks.py:888
  /home/travis/build/alerta/alerta/tests/test_webhooks.py:888: PytestWarning: cannot collect test class 'TestJsonWebhook' because it has a __init__ constructor
    class TestJsonWebhook(WebhookBase):
tests/test_webhooks.py:899
  /home/travis/build/alerta/alerta/tests/test_webhooks.py:899: PytestWarning: cannot collect test class 'TestTextWebhook' because it has a __init__ constructor
    class TestTextWebhook(WebhookBase):
tests/test_webhooks.py:910
  /home/travis/build/alerta/alerta/tests/test_webhooks.py:910: PytestWarning: cannot collect test class 'TestFormWebhook' because it has a __init__ constructor
    class TestFormWebhook(WebhookBase):
tests/test_webhooks.py:921
  /home/travis/build/alerta/alerta/tests/test_webhooks.py:921: PytestWarning: cannot collect test class 'TestMultiPartFormWebhook' because it has a __init__ constructor
    class TestMultiPartFormWebhook(WebhookBase):
tests/test_webhooks.py:932
  /home/travis/build/alerta/alerta/tests/test_webhooks.py:932: PytestWarning: cannot collect test class 'TestUserDefinedWebhook' because it has a __init__ constructor
    class TestUserDefinedWebhook(WebhookBase):

```

https://travis-ci.org/alerta/alerta/jobs/571685340#L451