### PR TITLE
Sort tags for deterministic comparison

### DIFF
--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -509,7 +509,7 @@ class AlertsTestCase(unittest.TestCase):
         response = self.client.get('/alert/' + alert_id)
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(data['alert']['tags'], ['foo', 'bar'])
+        self.assertEqual(sorted(data['alert']['tags']), ['bar', 'foo'])
 
         # duplicate tag is a no-op
         response = self.client.put('/alert/' + alert_id + '/tag',
@@ -518,7 +518,7 @@ class AlertsTestCase(unittest.TestCase):
         response = self.client.get('/alert/' + alert_id)
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(data['alert']['tags'], ['foo', 'bar'])
+        self.assertEqual(sorted(data['alert']['tags']), ['bar', 'foo'])
 
         # delete tag
         response = self.client.put('/alert/' + alert_id + '/untag',


### PR DESCRIPTION


ALERTA_SVR_CONF_FILE= DATABASE_URL=postgres:///test python3 -m pytest
============================= test session starts ==============================
platform linux -- Python 3.7.3, pytest-5.0.1, py-1.8.0, pluggy-0.12.0
rootdir: /home
plugins: requests-mock-1.6.0
collected 122 items
alerta/tests/test_actions.py .. [ 1%]
alerta/tests/test_aggregations.py . [ 2%]
alerta/tests/test_alerts.py .....F..
=================================== FAILURES ===================================
__ AlertsTestCase.test_alerttagging __
self = <tests.test_alerts.AlertsTestCase testMethod=test_alert_tagging>

E AssertionError: Lists differ: ['bar', 'foo'] != ['foo', 'bar']
E
E First differing element 0:
E 'bar'
E 'foo'
E
E - ['bar', 'foo']
E + ['foo', 'bar']
alerta/tests/test_alerts.py:512: AssertionError`

/cc @binhvcom