### PR TITLE
Support MongoDB seedlist connection format

### DIFF
--- a/alerta/database/base.py
+++ b/alerta/database/base.py
@@ -18,6 +18,8 @@ def get_backend(app):
     db_uri = app.config['DATABASE_URL']
     backend = urlparse(db_uri).scheme
 
+    if backend.startswith('mongodb'):
+        backend = 'mongodb'
     if backend == 'postgresql':
         backend = 'postgres'
     return backend


### PR DESCRIPTION
**Example DNS seedlist connection string**
```
mongodb+srv://server.example.com/
```

See https://docs.mongodb.com/manual/reference/connection-string/#connections-dns-seedlist

Fixes #1069 