### PR TITLE
utils/audit.py:get_redacted_data: check that data is defined

### DIFF
--- a/alerta/utils/audit.py
+++ b/alerta/utils/audit.py
@@ -82,7 +82,7 @@ class AuditTrail:
 
         def get_redacted_data(r):
             data = r.get_json()
-            if app.config['AUDIT_LOG_REDACT']:
+            if data and app.config['AUDIT_LOG_REDACT']:
                 if 'password' in data:
                     data['password'] = '[REDACTED]'
             return json.dumps(data)


### PR DESCRIPTION
otherwise (at lease heartbeat delete) can fail with:
File "alerta/utils/audit.py", line 86, in get_redacted_data
if 'password' in data:
TypeError: argument of type 'NoneType' is not iterable
