### PR TITLE
Added guest user with the scope of "read.alerts"

### DIFF
--- a/alerta/views/permissions.py
+++ b/alerta/views/permissions.py
@@ -75,6 +75,11 @@ def list_perms():
         scopes=current_app.config['USER_DEFAULT_SCOPES']
     )
 
+    guest_perm = Permission(
+        match='guest',
+        scopes=[Scope.read_alerts]
+    )
+
     # add system-defined roles 'admin' and 'user'
     if 'scopes' in request.args:
         want_scopes = request.args.getlist('scopes')
@@ -82,9 +87,12 @@ def list_perms():
             perms.append(admin_perm)
         if set(user_perm.scopes) & set(want_scopes):
             perms.append(user_perm)
+        if set(guest_perm.scopes) & set(want_scopes):
+            perms.append(guest_perm)
     else:
         perms.append(admin_perm)
         perms.append(user_perm)
+        perms.append(guest_perm)
 
     if perms:
         return jsonify(


### PR DESCRIPTION
_**Is your request related to a problem? Please describe.**_

It is, the problem is when you setup several alerta instances, you have to add guest user with read only role named at the start manually.

_**Describe the solution you'd like**_

We can create a guest user with a read only role(read.alerts only) at initial setup of docker image or alerta app.

_**Describe solutions you've considered**_

We created the role by hand which was not very convenient for multiple setups.


I actually tested this with some change to the "permission.py" file. I created an extra user with the scope of 'read:alerts'. So adding few lines of code we can actually have 3 IdP roles ready at start.

- Admin(Scope: Admin)
- User(Scope: Write,Read)
- Guest(Scope: Read.alerts)


Extra context & screenshots:
![Screenshot from 2020-01-21 15-48-22](https://user-images.githubusercontent.com/49399656/72873250-6579d900-3d00-11ea-9f1e-017809d3e12c.png)
![image](https://user-images.githubusercontent.com/49399656/72873318-90642d00-3d00-11ea-986a-a89a29cf7902.png)

