### PR TITLE
Use lastReceiveTime and createTime for blackouts

### DIFF
--- a/alerta/database/backends/mongodb/base.py
+++ b/alerta/database/backends/mongodb/base.py
@@ -891,11 +891,19 @@ class Backend(Database):
 
     def is_blackout_period(self, alert):
         query = dict()
-        query['startTime'] = {'$lte': alert.create_time}
-        query['endTime'] = {'$gt': alert.create_time}
-
         query['environment'] = alert.environment
-        query['$and'] = [{'$or': [
+        query['$and'] = [
+            {'$or': [
+                {'$and': [
+                    {'startTime': {'$lte': alert.create_time}},
+                    {'endTime': {'$gt': alert.create_time}}
+                ]},
+                {'$and': [
+                    {'startTime': {'$lte': alert.last_receive_time}},
+                    {'endTime': {'$gt': alert.last_receive_time}}
+                ]},
+            ]},
+            {'$or': [
             {
                 'resource': None,
                 'service': None,

--- a/alerta/database/backends/mongodb/base.py
+++ b/alerta/database/backends/mongodb/base.py
@@ -904,231 +904,232 @@ class Backend(Database):
                 ]},
             ]},
             {'$or': [
-            {
-                'resource': None,
-                'service': None,
-                'event': None,
-                'group': None,
-                'tags': None
-            },
-            {
-                'resource': None,
-                'service': None,
-                'event': None,
-                'group': None,
-                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
-            },
-            {
-                'resource': None,
-                'service': None,
-                'event': None,
-                'group': alert.group,
-                'tags': None
-            },
-            {
-                'resource': None,
-                'service': None,
-                'event': None,
-                'group': alert.group,
-                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
-            },
-            {
-                'resource': None,
-                'service': None,
-                'event': alert.event,
-                'group': None,
-                'tags': None
-            },
-            {
-                'resource': None,
-                'service': None,
-                'event': alert.event,
-                'group': None,
-                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
-            },
-            {
-                'resource': None,
-                'service': None,
-                'event': alert.event,
-                'group': alert.group,
-                'tags': None
-            },
-            {
-                'resource': None,
-                'service': None,
-                'event': alert.event,
-                'group': alert.group,
-                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
-            },
-            {
-                'resource': None,
-                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': None,
-                'group': None,
-                'tags': None
-            },
-            {
-                'resource': None,
-                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': None,
-                'group': None,
-                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
-            },
-            {
-                'resource': None,
-                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': None,
-                'group': alert.group,
-                'tags': None
-            },
-            {
-                'resource': None,
-                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': None,
-                'group': alert.group,
-                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
-            },
-            {
-                'resource': None,
-                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': alert.event,
-                'group': None,
-                'tags': None
-            },
-            {
-                'resource': None,
-                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': alert.event,
-                'group': None,
-                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
-            },
-            {
-                'resource': None,
-                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': alert.event,
-                'group': alert.group,
-                'tags': None
-            },
-            {
-                'resource': None,
-                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': alert.event,
-                'group': alert.group,
-                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
-            },
-            {
-                'resource': alert.resource,
-                'service': None,
-                'event': None,
-                'group': None,
-                'tags': None
-            },
-            {
-                'resource': alert.resource,
-                'service': None,
-                'event': None,
-                'group': None,
-                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
-            },
-            {
-                'resource': alert.resource,
-                'service': None,
-                'event': None,
-                'group': alert.group,
-                'tags': None
-            },
-            {
-                'resource': alert.resource,
-                'service': None,
-                'event': None,
-                'group': alert.group,
-                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
-            },
-            {
-                'resource': alert.resource,
-                'service': None,
-                'event': alert.event,
-                'group': None,
-                'tags': None
-            },
-            {
-                'resource': alert.resource,
-                'service': None,
-                'event': alert.event,
-                'group': None,
-                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
-            },
-            {
-                'resource': alert.resource,
-                'service': None,
-                'event': alert.event,
-                'group': alert.group,
-                'tags': None
-            },
-            {
-                'resource': alert.resource,
-                'service': None,
-                'event': alert.event,
-                'group': alert.group,
-                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
-            },
-            {
-                'resource': alert.resource,
-                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': None,
-                'group': None,
-                'tags': None
-            },
-            {
-                'resource': alert.resource,
-                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': None,
-                'group': None,
-                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
-            },
-            {
-                'resource': alert.resource,
-                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': None,
-                'group': alert.group,
-                'tags': None
-            },
-            {
-                'resource': alert.resource,
-                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': None,
-                'group': alert.group,
-                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
-            },
-            {
-                'resource': alert.resource,
-                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': alert.event,
-                'group': None,
-                'tags': None
-            },
-            {
-                'resource': alert.resource,
-                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': alert.event,
-                'group': None,
-                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
-            },
-            {
-                'resource': alert.resource,
-                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': alert.event,
-                'group': alert.group,
-                'tags': None
-            },
-            {
-                'resource': alert.resource,
-                'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
-                'event': alert.event,
-                'group': alert.group,
-                'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
-            }
-        ]}]
+                {
+                    'resource': None,
+                    'service': None,
+                    'event': None,
+                    'group': None,
+                    'tags': None
+                },
+                {
+                    'resource': None,
+                    'service': None,
+                    'event': None,
+                    'group': None,
+                    'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
+                },
+                {
+                    'resource': None,
+                    'service': None,
+                    'event': None,
+                    'group': alert.group,
+                    'tags': None
+                },
+                {
+                    'resource': None,
+                    'service': None,
+                    'event': None,
+                    'group': alert.group,
+                    'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
+                },
+                {
+                    'resource': None,
+                    'service': None,
+                    'event': alert.event,
+                    'group': None,
+                    'tags': None
+                },
+                {
+                    'resource': None,
+                    'service': None,
+                    'event': alert.event,
+                    'group': None,
+                    'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
+                },
+                {
+                    'resource': None,
+                    'service': None,
+                    'event': alert.event,
+                    'group': alert.group,
+                    'tags': None
+                },
+                {
+                    'resource': None,
+                    'service': None,
+                    'event': alert.event,
+                    'group': alert.group,
+                    'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
+                },
+                {
+                    'resource': None,
+                    'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
+                    'event': None,
+                    'group': None,
+                    'tags': None
+                },
+                {
+                    'resource': None,
+                    'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
+                    'event': None,
+                    'group': None,
+                    'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
+                },
+                {
+                    'resource': None,
+                    'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
+                    'event': None,
+                    'group': alert.group,
+                    'tags': None
+                },
+                {
+                    'resource': None,
+                    'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
+                    'event': None,
+                    'group': alert.group,
+                    'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
+                },
+                {
+                    'resource': None,
+                    'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
+                    'event': alert.event,
+                    'group': None,
+                    'tags': None
+                },
+                {
+                    'resource': None,
+                    'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
+                    'event': alert.event,
+                    'group': None,
+                    'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
+                },
+                {
+                    'resource': None,
+                    'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
+                    'event': alert.event,
+                    'group': alert.group,
+                    'tags': None
+                },
+                {
+                    'resource': None,
+                    'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
+                    'event': alert.event,
+                    'group': alert.group,
+                    'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
+                },
+                {
+                    'resource': alert.resource,
+                    'service': None,
+                    'event': None,
+                    'group': None,
+                    'tags': None
+                },
+                {
+                    'resource': alert.resource,
+                    'service': None,
+                    'event': None,
+                    'group': None,
+                    'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
+                },
+                {
+                    'resource': alert.resource,
+                    'service': None,
+                    'event': None,
+                    'group': alert.group,
+                    'tags': None
+                },
+                {
+                    'resource': alert.resource,
+                    'service': None,
+                    'event': None,
+                    'group': alert.group,
+                    'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
+                },
+                {
+                    'resource': alert.resource,
+                    'service': None,
+                    'event': alert.event,
+                    'group': None,
+                    'tags': None
+                },
+                {
+                    'resource': alert.resource,
+                    'service': None,
+                    'event': alert.event,
+                    'group': None,
+                    'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
+                },
+                {
+                    'resource': alert.resource,
+                    'service': None,
+                    'event': alert.event,
+                    'group': alert.group,
+                    'tags': None
+                },
+                {
+                    'resource': alert.resource,
+                    'service': None,
+                    'event': alert.event,
+                    'group': alert.group,
+                    'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
+                },
+                {
+                    'resource': alert.resource,
+                    'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
+                    'event': None,
+                    'group': None,
+                    'tags': None
+                },
+                {
+                    'resource': alert.resource,
+                    'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
+                    'event': None,
+                    'group': None,
+                    'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
+                },
+                {
+                    'resource': alert.resource,
+                    'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
+                    'event': None,
+                    'group': alert.group,
+                    'tags': None
+                },
+                {
+                    'resource': alert.resource,
+                    'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
+                    'event': None,
+                    'group': alert.group,
+                    'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
+                },
+                {
+                    'resource': alert.resource,
+                    'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
+                    'event': alert.event,
+                    'group': None,
+                    'tags': None
+                },
+                {
+                    'resource': alert.resource,
+                    'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
+                    'event': alert.event,
+                    'group': None,
+                    'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
+                },
+                {
+                    'resource': alert.resource,
+                    'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
+                    'event': alert.event,
+                    'group': alert.group,
+                    'tags': None
+                },
+                {
+                    'resource': alert.resource,
+                    'service': {'$not': {'$elemMatch': {'$nin': alert.service}}},
+                    'event': alert.event,
+                    'group': alert.group,
+                    'tags': {'$not': {'$elemMatch': {'$nin': alert.tags}}}
+                }
+            ]}
+        ]
 
         if current_app.config['CUSTOMER_VIEWS']:
             query['$and'].append({'$or': [{'customer': None}, {'customer': alert.customer}]})

--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -685,7 +685,8 @@ class Backend(Database):
         select = """
             SELECT *
             FROM blackouts
-            WHERE start_time <= %(create_time)s AND end_time > %(create_time)s
+            WHERE ((start_time <= %(create_time)s AND end_time > %(create_time)s)
+              OR (start_time <= %(last_receive_time)s AND end_time > %(last_receive_time)s))
               AND environment=%(environment)s
               AND (
                  (resource IS NULL AND service='{}' AND event IS NULL AND "group" IS NULL AND tags='{}')


### PR DESCRIPTION
Changing `createTime` to `receiveTime` would have just reintroduced the problem fixed by #891. The solution was to use both `createTime` (which is what it uses currently) for newly created alerts during a blackout period and `receiveTime` (or more correctly, `lastReceiveTime`) for alert duplicates created during a blackout period.

Fixes #1132 