### PR TITLE
Add Python 3.8 to supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 
 env:
   - DB=mongodb DATABASE_URL=mongodb://localhost:27017/alerta5

--- a/alerta/app.py
+++ b/alerta/app.py
@@ -53,7 +53,7 @@ def create_app(config_override: Dict[str, Any] = None, environment: str = None) 
     logger.setup_logging(app)
 
     if app.config['USE_PROXYFIX']:
-        app.wsgi_app = ProxyFix(app.wsgi_app)
+        app.wsgi_app = ProxyFix(app.wsgi_app)  # type: ignore
 
     hooks.init_app(app)
     audit.init_app(app)

--- a/alerta/auth/utils.py
+++ b/alerta/auth/utils.py
@@ -95,7 +95,7 @@ def send_password_reset(user: 'User', token: str) -> None:
            '{url}\n\n' \
            'You\'re receiving this email because you asked for a password reset of an Alerta account.' \
            ' If this wasn\'t you, please ignore this email.'.format(
-               name=user.name, email=user.email, url=link(request.referrer, 'reset', token)
+               url=link(request.referrer, 'reset', token)
            )
     mailer.send_email(user.email, subject, body=text)
 

--- a/alerta/exceptions.py
+++ b/alerta/exceptions.py
@@ -76,6 +76,7 @@ class ExceptionHandlers:
 
 
 def handle_http_error(error: HTTPException) -> Tuple[Response, int]:
+    error.code = error.code or 500
     if error.code >= 500:
         current_app.logger.exception(error)
     return jsonify({

--- a/alerta/exceptions.py
+++ b/alerta/exceptions.py
@@ -45,6 +45,7 @@ class NoCustomerMatch(AlertaException):
 
 class BaseError(Exception):
     code = 500
+    description = 'Unhandled exception'
 
     def __init__(self, message, code=None, errors=None):
         super().__init__(message)

--- a/alerta/models/alarms/alerta.py
+++ b/alerta/models/alarms/alerta.py
@@ -1,6 +1,6 @@
 from flask import current_app
 
-from alerta.exceptions import InvalidAction
+from alerta.exceptions import ApiError, InvalidAction
 from alerta.models.alarms import AlarmModel
 
 SEVERITY_MAP = {
@@ -130,8 +130,8 @@ class StateMachine(AlarmModel):
         previous_severity = alert.previous_severity or StateMachine.DEFAULT_PREVIOUS_SEVERITY
 
         valid_severities = sorted(StateMachine.Severity, key=StateMachine.Severity.get)
-        assert current_severity in StateMachine.Severity, 'Severity ({}) is not one of {}'.format(
-            current_severity, ', '.join(valid_severities))
+        if current_severity not in StateMachine.Severity:
+            raise ApiError('Severity ({}) is not one of {}'.format(current_severity, ', '.join(valid_severities)), 400)
 
         def next_state(rule, severity, status):
             current_app.logger.info(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-mypy==0.620
+mypy
 pre-commit
 pytest
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setuptools.setup(
         'Intended Audience :: System Administrators',
         'Intended Audience :: Telecommunications Industry',
         'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.5',


### PR DESCRIPTION
Python 3.8 was released last October.

<img width="821" alt="Screenshot 2020-02-10 at 19 57 05" src="https://user-images.githubusercontent.com/615057/74180286-89fe0c80-4c3f-11ea-99cd-c53c001134dd.png">

See https://devguide.python.org/#status-of-python-branches

Note: Remove Python 3.5 in September, 2020.
