### PR TITLE
Allow to log audited alert data as JSON object

### DIFF
--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -122,7 +122,7 @@ API_KEY_EXPIRE_DAYS = 365  # 1 year
 AUDIT_TRAIL = ['admin']  # possible categories are 'admin', 'write', and 'auth'
 AUDIT_LOG = None  # set to True to log to application logger
 AUDIT_LOG_REDACT = True  # redact sensitive data before logging
-AUDIT_LOG_JSON = False # log alert data as JSON object
+AUDIT_LOG_JSON = False  # log alert data as JSON object
 AUDIT_URL = None  # send audit log events via webhook URL
 
 # CORS settings

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -122,6 +122,7 @@ API_KEY_EXPIRE_DAYS = 365  # 1 year
 AUDIT_TRAIL = ['admin']  # possible categories are 'admin', 'write', and 'auth'
 AUDIT_LOG = None  # set to True to log to application logger
 AUDIT_LOG_REDACT = True  # redact sensitive data before logging
+AUDIT_LOG_JSON = False # log alert data as JSON object
 AUDIT_URL = None  # send audit log events via webhook URL
 
 # CORS settings

--- a/alerta/utils/audit.py
+++ b/alerta/utils/audit.py
@@ -85,6 +85,8 @@ class AuditTrail:
             if data and app.config['AUDIT_LOG_REDACT']:
                 if 'password' in data:
                     data['password'] = '[REDACTED]'
+            if app.config['AUDIT_LOG_JSON']:
+                return data
             return json.dumps(data)
 
         return json.dumps({


### PR DESCRIPTION
I would like to log the alert data in audit as JSON object. So it could be used directly instead of parsing the data attribute again.