### PR TITLE
Read default keycloak realm and resouce based roles and groups

### DIFF
--- a/alerta/auth/oidc.py
+++ b/alerta/auth/oidc.py
@@ -127,8 +127,8 @@ def openid():
             group_claim: access_token.get('realm_access', {}).get(group_claim, []) +
                          access_token.get('resource_access', {}).get(client_id, {}).get(group_claim, []),
         }
-    except Exception:
-        current_app.logger.warning('No access token in OpenID Connect token response.')
+    except Exception as err:
+        current_app.logger.warning('No access token in OpenID Connect token response: %s', err)
         keycloak_claims = {}
 
     try:

--- a/alerta/auth/oidc.py
+++ b/alerta/auth/oidc.py
@@ -148,8 +148,8 @@ def openid():
     picture = userinfo.get('picture') or id_token.get('picture')
 
     custom_claims = {
-        role_claim: keycloak_claims.get(role_claim) or userinfo.get(role_claim) or id_token.get(role_claim) or [],
-        group_claim: keycloak_claims.get(group_claim) or userinfo.get(group_claim) or id_token.get(group_claim) or [],
+        role_claim: keycloak_claims.get(role_claim, []) + userinfo.get(role_claim, []) + id_token.get(role_claim, []),
+        group_claim: keycloak_claims.get(group_claim, []) + userinfo.get(group_claim, []) + id_token.get(group_claim, []),
     }
 
     login = username or nickname or email

--- a/alerta/auth/oidc.py
+++ b/alerta/auth/oidc.py
@@ -67,9 +67,9 @@ def openid():
     oidc_configuration, jwt_key_set = get_oidc_configuration(current_app)
     token_endpoint = oidc_configuration['token_endpoint']
     userinfo_endpoint = oidc_configuration['userinfo_endpoint']
-    client_id = current_app.config['OIDC_CLIENT_ID']
-    role_claim = current_app.config['OIDC_ROLE_CLAIM']
-    group_claim = current_app.config['OIDC_GROUP_CLAIM']
+    client_id = current_app.config.get('OIDC_CLIENT_ID')
+    role_claim = current_app.config.get('OIDC_ROLE_CLAIM')
+    group_claim = current_app.config.get('OIDC_GROUP_CLAIM')
 
     data = {
         'grant_type': 'authorization_code',

--- a/alerta/auth/oidc.py
+++ b/alerta/auth/oidc.py
@@ -127,8 +127,8 @@ def openid():
     role_claim = current_app.config['OIDC_ROLE_CLAIM']
     group_claim = current_app.config['OIDC_GROUP_CLAIM']
     custom_claims = {
-+        'role_claim': deep_get(userinfo, role_claim) or deep_get(id_token, role_claim) or [],
-+        'group_claim': deep_get(userinfo, group_claim) or deep_get(id_token, group_claim) or [],
++        'role_claim': _deep_get(userinfo, role_claim) or _deep_get(id_token, role_claim) or [],
++        'group_claim': _deep_get(userinfo, group_claim) or _deep_get(id_token, group_claim) or [],
     }
 
     login = username or nickname or email

--- a/alerta/auth/oidc.py
+++ b/alerta/auth/oidc.py
@@ -117,18 +117,18 @@ def openid():
     email_verified = True if email_verified == 'true' else email_verified  # Cognito returns string boolean
     picture = userinfo.get('picture') or id_token.get('picture')
  
-    def _deep_get(data, key, default=None):
+    def _deep_get(data, key):
         from functools import reduce
         if type(key) is list:
-            return reduce(lambda d, k: d.get(k) if d else None, key, data) or default
+            return reduce(lambda d, k: d.get(k) if d else None, key, data)
         else:
-            data.get(key, default)
+            data.get(key)
 
     role_claim = current_app.config['OIDC_ROLE_CLAIM']
     group_claim = current_app.config['OIDC_GROUP_CLAIM']
     custom_claims = {
-        'role_claim': _deep_get(userinfo, role_claim) or _deep_get(id_token, role_claim, []),
-        'group_claim': _deep_get(userinfo, group_claim) or _deep_get(id_token, group_claim, []),
++        'role_claim': deep_get(userinfo, role_claim) or deep_get(id_token, role_claim) or [],
++        'group_claim': deep_get(userinfo, group_claim) or deep_get(id_token, group_claim) or [],
     }
 
     login = username or nickname or email

--- a/alerta/auth/oidc.py
+++ b/alerta/auth/oidc.py
@@ -67,6 +67,7 @@ def openid():
     oidc_configuration, jwt_key_set = get_oidc_configuration(current_app)
     token_endpoint = oidc_configuration['token_endpoint']
     userinfo_endpoint = oidc_configuration['userinfo_endpoint']
+    client_id = current_app.config['OIDC_CLIENT_ID']
     role_claim = current_app.config['OIDC_ROLE_CLAIM']
     group_claim = current_app.config['OIDC_GROUP_CLAIM']
 
@@ -120,12 +121,11 @@ def openid():
                 verify=False
             )
 
-        audience = access_token.get('aud')
         keycloak_claims = {
             role_claim: access_token.get('realm_access', {}).get(role_claim, []) +
-                        access_token.get('resource_access', {}).get(audience, {}).get(role_claim, []),
+                        access_token.get('resource_access', {}).get(client_id, {}).get(role_claim, []),
             group_claim: access_token.get('realm_access', {}).get(group_claim, []) +
-                         access_token.get('resource_access', {}).get(audience, {}).get(group_claim, []),
+                         access_token.get('resource_access', {}).get(client_id, {}).get(group_claim, []),
         }
     except Exception:
         current_app.logger.warning('No access token in OpenID Connect token response.')

--- a/alerta/auth/oidc.py
+++ b/alerta/auth/oidc.py
@@ -105,8 +105,8 @@ def openid():
         id_token = {}
 
     # keycloak specific: roles and groups in access_token
-    try:
-        if current_app.config['OIDC_VERIFY_TOKEN']:
+    #try:
+    if current_app.config['OIDC_VERIFY_TOKEN']:
             jwt_header = jwt.get_unverified_header(token['id_token'])
             public_key = jwt_key_set[jwt_header['kid']]
 
@@ -115,21 +115,21 @@ def openid():
                 key=public_key,
                 algorithms=jwt_header['alg']
             )
-        else:
+    else:
             access_token = jwt.decode(
                 token['access_token'],
                 verify=False
             )
 
-        keycloak_claims = {
+    keycloak_claims = {
             role_claim: access_token.get('realm_access', {}).get(role_claim, []) +
                         access_token.get('resource_access', {}).get(client_id, {}).get(role_claim, []),
             group_claim: access_token.get('realm_access', {}).get(group_claim, []) +
                          access_token.get('resource_access', {}).get(client_id, {}).get(group_claim, []),
-        }
-    except Exception as err:
-        current_app.logger.warning('No access token in OpenID Connect token response: %s', err)
-        keycloak_claims = {}
+    }
+    #except Exception:
+    #    current_app.logger.warning('No access token in OpenID Connect token response.')
+    #    keycloak_claims = {}
 
     try:
         headers = {'Authorization': '{} {}'.format(token.get('token_type', 'Bearer'), token['access_token'])}

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1076,6 +1076,7 @@ class AuthProvidersTestCase(unittest.TestCase):
             'AUTH_PROVIDER': 'keycloak',
             'KEYCLOAK_URL': 'http://keycloak.local.alerta.io:9090',
             'KEYCLOAK_REALM': 'master',
+            'OIDC_CLIENT_ID': 'alerta-ui',
             'OIDC_CUSTOM_CLAIM': 'roles',
             # 'OIDC_ISSUER_URL': 'http://keycloak.local.alerta.io:9090/auth/realms/master',
             # 'OIDC_ROLE_CLAIM': 'roles',
@@ -1311,8 +1312,8 @@ class AuthProvidersTestCase(unittest.TestCase):
         self.assertEqual(claims['name'], 'Nicholas Satterly', claims)
         self.assertEqual(claims['preferred_username'], 'nsatterl', claims)
         self.assertEqual(claims['provider'], 'keycloak', claims)
-        self.assertSetEqual(set(claims['roles']), set(['create-realm', 'devops', 'alerta-project', 'admin', 'realm_role_1',
-                                                       'realm_role_2', 'resource_role_1', 'resource_role_2']), claims)
+        self.assertSetEqual(set(claims['roles']), {'create-realm', 'devops', 'alerta-project', 'admin', 'realm_role_1',
+                                                   'realm_role_2', 'resource_role_1', 'resource_role_2'}, claims)
         self.assertEqual(claims['scope'], 'admin read write', claims)
         self.assertEqual(claims['email'], 'nick@alerta.dev', claims)
         self.assertEqual(claims.get('email_verified'), True, claims)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1230,7 +1230,27 @@ class AuthProvidersTestCase(unittest.TestCase):
           "id_token": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJ2ZTY3NUpULWlsdXJQWWdUbDMtQ0htWmFwLVZ0LXVjTWJFdjNudktjNkljIn0.eyJqdGkiOiI0MjIzMGI4My1hOGM4LTQ0ODEtYWE5My1mMjMwNzk5YWVjMmQiLCJleHAiOjE1NTQxNTc4NTMsIm5iZiI6MCwiaWF0IjoxNTU0MTU3NzkzLCJpc3MiOiJodHRwOi8va2V5Y2xvYWsubG9jYWwuYWxlcnRhLmlvOjkwOTAvYXV0aC9yZWFsbXMvbWFzdGVyIiwiYXVkIjoiYWxlcnRhLXVpIiwic3ViIjoiNGVlYWExMjItMDhkOC00N2JjLWI2ZDAtMDEwNDgxYzA1NWM1IiwidHlwIjoiSUQiLCJhenAiOiJhbGVydGEtdWkiLCJhdXRoX3RpbWUiOjE1NTQxNTc3ODQsInNlc3Npb25fc3RhdGUiOiI2NmExNDIyYS1jYjI4LTQ3MmMtYWE3NC1iOGIxM2I1MDhkZGMiLCJhY3IiOiIwIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsInJvbGVzIjpbImNyZWF0ZS1yZWFsbSIsImRldm9wcyIsImFkbWluIl0sIm5hbWUiOiJOaWNob2xhcyBTYXR0ZXJseSIsInByZWZlcnJlZF91c2VybmFtZSI6Im5zYXR0ZXJsIiwiZ2l2ZW5fbmFtZSI6Ik5pY2hvbGFzIiwiZmFtaWx5X25hbWUiOiJTYXR0ZXJseSIsImVtYWlsIjoibmlja0BhbGVydGEuZGV2In0.H78MN_uRbniCEE6zOKFH9v2l5O_-JaNiP3W7CYiUR2sbA5H0e_vnFRy93A_RhKGiXBdEq-Lop6aE-BPgGgZpBR-G0wi9y0-pPRr3K3UHIL7z8ozUerXJ3g5DzQu3zFyHF9v62ew12YtBzRwebl2mW0_32_zEMlQPs3AzN2LxsjQT5QBV7nzygO_5xfgfA55guiBvJ8D8be13__wO-iQsFnnnFGK6JEbNDTM-M0JXqt4FtRfSEOdCjKRdLSUIfReTo1k2FrD2gtoVOcTOzUN6FCUefa8E52Xy3sgrWSHGUoE9brfoOvzoponiHUVCmbnPhHRTqBOSMZyfDw28v6z63Q",
           "not-before-policy": 0,
           "session_state": "66a1422a-cb28-472c-aa74-b8b13b508ddc",
-          "scope": "openid email profile"
+          "scope": "openid email profile",
+          "realm_access": {
+            "roles": [
+              "realm_role_1",
+              "realm_role_2"
+            ]
+          },
+          "resource_access": {
+            "alerta-ui": {
+              "roles": [
+                "resource_role_1",
+                "resource_role_2"
+              ]
+            },
+            "other": {
+              "roles": [
+                "resource_role_3",
+                "resource_role_4"
+              ]
+            }
+          }
         }
         """
 
@@ -1291,7 +1311,8 @@ class AuthProvidersTestCase(unittest.TestCase):
         self.assertEqual(claims['name'], 'Nicholas Satterly', claims)
         self.assertEqual(claims['preferred_username'], 'nsatterl', claims)
         self.assertEqual(claims['provider'], 'keycloak', claims)
-        self.assertEqual(claims['roles'], ['create-realm', 'devops', 'alerta-project', 'admin'], claims)
+        self.assertEqual(claims['roles'], ['create-realm', 'devops', 'alerta-project', 'admin', 'realm_role_1',
+                                           'realm_role_2', 'resource_role_1', 'resource_role_2'], claims)
         self.assertEqual(claims['scope'], 'admin read write', claims)
         self.assertEqual(claims['email'], 'nick@alerta.dev', claims)
         self.assertEqual(claims.get('email_verified'), True, claims)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1311,8 +1311,8 @@ class AuthProvidersTestCase(unittest.TestCase):
         self.assertEqual(claims['name'], 'Nicholas Satterly', claims)
         self.assertEqual(claims['preferred_username'], 'nsatterl', claims)
         self.assertEqual(claims['provider'], 'keycloak', claims)
-        self.assertEqual(claims['roles'], ['create-realm', 'devops', 'alerta-project', 'admin', 'realm_role_1',
-                                           'realm_role_2', 'resource_role_1', 'resource_role_2'], claims)
+        self.assertSetEqual(set(claims['roles']), set(['create-realm', 'devops', 'alerta-project', 'admin', 'realm_role_1',
+                                                       'realm_role_2', 'resource_role_1', 'resource_role_2']), claims)
         self.assertEqual(claims['scope'], 'admin read write', claims)
         self.assertEqual(claims['email'], 'nick@alerta.dev', claims)
         self.assertEqual(claims.get('email_verified'), True, claims)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -720,7 +720,8 @@ class AuthProvidersTestCase(unittest.TestCase):
             'AUTH_REQUIRED': True,
             'AUTH_PROVIDER': 'gitlab',
             # 'OIDC_ISSUER_URL': 'https://gitlab.com',
-            # 'OIDC_CUSTOM_CLAIM': 'groups',
+            'OIDC_CUSTOM_CLAIM': 'groups',
+            'OIDC_ROLE_CLAIM': 'groups',
             'ALLOWED_GITLAB_GROUPS': ['alerta-project'],
             'CUSTOMER_VIEWS': True,
         }


### PR DESCRIPTION
Implemented the ability to read the default keycloak realm and resource based roles and groups. Yes, there is a documentation how to configure right but in my case I'm not able to change the configuration because it's a central provided service. Additionally this is the default keycloak configuration and nothing special for my deployment.

```json
{
  "name": "Me",
  "email": "me@example.com",
  "realm_access": {
    "roles": [
      "just_some_generic_roles"
    ]
  },
  "resource_access": {
    "RANDOM_OAUTH2_CLIENT_ID": {
      "roles": [
        "my_role_1",
        "my_role_2"
      ]
    }
  }
}
```

We already discussed this at https://github.com/alerta/alerta/issues/1073

This implementation uses the keycloak-gatekeeper (proxy service for keycloak) as a basis: https://github.com/keycloak/keycloak-gatekeeper/blob/master/user_context.go#L56-L76