### PR TITLE
Support webhooks with a subpath

### DIFF
--- a/alerta/webhooks/__init__.py
+++ b/alerta/webhooks/__init__.py
@@ -35,9 +35,9 @@ class WebhookBase(metaclass=abc.ABCMeta):
             LOG.info('\n{}\n'.format(self.__doc__))
 
     @abc.abstractmethod
-    def incoming(self, query_string: ImmutableMultiDict, payload: Any) -> Union[Alert, JSON]:
+    def incoming(self, path: str, query_string: ImmutableMultiDict, payload: Any) -> Union[Alert, JSON]:
         """
-        Parse webhook query string and/or payload in JSON or plain text and
+        Parse webhook path, query string and/or payload in JSON or plain text and
         return an alert or a custom JSON response.
         """
         raise NotImplementedError

--- a/alerta/webhooks/cloudwatch.py
+++ b/alerta/webhooks/cloudwatch.py
@@ -27,7 +27,7 @@ class CloudWatchWebhook(WebhookBase):
         else:
             return 'unknown'
 
-    def incoming(self, query_string, payload):
+    def incoming(self, path, query_string, payload):
         notification = json.loads(payload)
 
         if notification['Type'] == 'SubscriptionConfirmation':

--- a/alerta/webhooks/custom.py
+++ b/alerta/webhooks/custom.py
@@ -13,14 +13,21 @@ from alerta.utils.audit import write_audit_trail
 from . import webhooks
 
 
-@webhooks.route('/webhooks/<webhook>', methods=['OPTIONS', 'GET', 'POST'])
+@webhooks.route('/webhooks/<webhook>', defaults={'path': ''}, methods=['OPTIONS', 'GET', 'POST'])
+@webhooks.route('/webhooks/<webhook>/<path:path>', methods=['OPTIONS', 'GET', 'POST'])
 @cross_origin()
 @permission(Scope.write_webhooks)
-def custom(webhook):
+def custom(webhook, path):
     if webhook not in custom_webhooks.webhooks:
         raise ApiError("Custom webhook '%s' not found." % webhook, 404)
 
     try:
+        rv = custom_webhooks.webhooks[webhook].incoming(
+            path=path or request.path,
+            query_string=request.args,
+            payload=request.get_json() or request.form or request.get_data(as_text=True)
+        )
+    except TypeError:
         rv = custom_webhooks.webhooks[webhook].incoming(
             query_string=request.args,
             payload=request.get_json() or request.form or request.get_data(as_text=True)

--- a/alerta/webhooks/grafana.py
+++ b/alerta/webhooks/grafana.py
@@ -63,7 +63,7 @@ class GrafanaWebhook(WebhookBase):
     See http://docs.grafana.org/alerting/notifications/#webhook
     """
 
-    def incoming(self, query_string, payload):
+    def incoming(self, path, query_string, payload):
 
         if payload and payload['state'] == 'alerting':
             return [parse_grafana(payload, match, query_string) for match in payload.get('evalMatches', [])]

--- a/alerta/webhooks/graylog.py
+++ b/alerta/webhooks/graylog.py
@@ -13,7 +13,7 @@ class GraylogWebhook(WebhookBase):
     See http://docs.graylog.org/en/3.0/pages/streams/alerts.html#http-alert-notification
     """
 
-    def incoming(self, query_string, payload):
+    def incoming(self, path, query_string, payload):
 
         return Alert(
             resource=payload['stream']['title'],

--- a/alerta/webhooks/newrelic.py
+++ b/alerta/webhooks/newrelic.py
@@ -13,7 +13,7 @@ class NewRelicWebhook(WebhookBase):
     See https://docs.newrelic.com/docs/alerts/new-relic-alerts/managing-notification-channels/notification-channels-control-where-send-alerts
     """
 
-    def incoming(self, query_string, payload):
+    def incoming(self, path, query_string, payload):
 
         if 'version' not in payload:
             raise ValueError('New Relic Legacy Alerting is not supported')

--- a/alerta/webhooks/pagerduty.py
+++ b/alerta/webhooks/pagerduty.py
@@ -63,7 +63,7 @@ class PagerDutyWebhook(WebhookBase):
     See https://v2.developer.pagerduty.com/docs/webhooks-v2-overview
     """
 
-    def incoming(self, query_string, payload):
+    def incoming(self, path, query_string, payload):
 
         updated = False
         if payload and 'messages' in payload:

--- a/alerta/webhooks/pingdom.py
+++ b/alerta/webhooks/pingdom.py
@@ -14,7 +14,7 @@ class PingdomWebhook(WebhookBase):
     See https://www.pingdom.com/resources/webhooks/
     """
 
-    def incoming(self, query_string, payload):
+    def incoming(self, path, query_string, payload):
 
         if payload['importance_level'] == 'HIGH':
             severity = 'critical'

--- a/alerta/webhooks/prometheus.py
+++ b/alerta/webhooks/prometheus.py
@@ -106,7 +106,7 @@ class PrometheusWebhook(WebhookBase):
     See https://prometheus.io/docs/operating/integrations/#alertmanager-webhook-receiver
     """
 
-    def incoming(self, query_string, payload):
+    def incoming(self, path, query_string, payload):
 
         if payload and 'alerts' in payload:
             external_url = payload.get('externalURL')

--- a/alerta/webhooks/riemann.py
+++ b/alerta/webhooks/riemann.py
@@ -13,7 +13,7 @@ class RiemannWebhook(WebhookBase):
     http://riemann.io/clients.html
     """
 
-    def incoming(self, query_string, payload):
+    def incoming(self, path, query_string, payload):
 
         return Alert(
             resource='{}-{}'.format(payload['host'], payload['service']),

--- a/alerta/webhooks/serverdensity.py
+++ b/alerta/webhooks/serverdensity.py
@@ -13,7 +13,7 @@ class ServerDensityWebhook(WebhookBase):
     See https://support.serverdensity.com/hc/en-us/articles/360001067183-Setting-up-webhooks
     """
 
-    def incoming(self, query_string, payload):
+    def incoming(self, path, query_string, payload):
 
         if payload['fixed']:
             severity = 'ok'

--- a/alerta/webhooks/slack.py
+++ b/alerta/webhooks/slack.py
@@ -75,7 +75,7 @@ class SlackWebhook(WebhookBase):
     See https://api.slack.com/slack-apps
     """
 
-    def incoming(self, query_string, payload):
+    def incoming(self, path, query_string, payload):
 
         alert_id, user, action = parse_slack(payload)
 

--- a/alerta/webhooks/stackdriver.py
+++ b/alerta/webhooks/stackdriver.py
@@ -17,7 +17,7 @@ class StackDriverWebhook(WebhookBase):
     See https://cloud.google.com/monitoring/support/notification-options#webhooks
     """
 
-    def incoming(self, query_string, payload):
+    def incoming(self, path, query_string, payload):
 
         incident = payload['incident']
         state = incident['state']

--- a/alerta/webhooks/telegram.py
+++ b/alerta/webhooks/telegram.py
@@ -67,7 +67,7 @@ class TelegramWebhook(WebhookBase):
     See https://core.telegram.org/bots/api
     """
 
-    def incoming(self, query_string, payload):
+    def incoming(self, path, query_string, payload):
 
         if 'callback_query' in payload:
             author = payload['callback_query']['from']

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -589,6 +589,24 @@ class WebhooksTestCase(unittest.TestCase):
         }
         """
 
+        self.vmware_vrealize = """
+        {
+           "startDate":1369757346267,
+           "criticality":"ALERT_CRITICALITY_LEVEL_WARNING",
+           "resourceId":"sample-object-uuid",
+           "alertId":"sample-alert-uuid",
+           "status":"ACTIVE",
+           "subType":"ALERT_SUBTYPE_AVAILABILITY_PROBLEM",
+           "cancelDate":1369757346267,
+           "resourceKind":"sample-object-type",
+           "adapterKind":"sample-adapter-type",
+           "type":"ALERT_TYPE_APPLICATION_PROBLEM",
+           "resourceName":"sample-object-name",
+           "updateDate":1369757346267,
+           "info":"sample-info"
+        }
+        """
+
         self.headers = {
             'Content-type': 'application/json',
             'X-Forwarded-For': ['10.1.1.1', '172.16.1.1', '192.168.1.1'],
@@ -831,6 +849,23 @@ class WebhooksTestCase(unittest.TestCase):
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(data['status'], 'error')
 
+    def test_vmware_webhook(self):
+
+        custom_webhooks.webhooks['vmware'] = VmwareWebhook()
+
+        # create alert
+        response = self.client.post('/webhooks/vmware/sample-alert-uuid', data=self.vmware_vrealize, headers=self.headers)
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['alert']['id'], 'sample-alert-uuid')
+        self.assertEqual(data['alert']['resource'], 'sample-object-name')
+        self.assertEqual(data['alert']['event'], 'ALERT_SUBTYPE_AVAILABILITY_PROBLEM')
+        self.assertEqual(data['alert']['service'], ['sample-object-type'])
+        self.assertEqual(data['alert']['severity'], 'critical')
+        self.assertEqual(data['alert']['group'], 'sample-object-type')
+        self.assertEqual(data['alert']['type'], 'ALERT_TYPE_APPLICATION_PROBLEM')
+        self.assertEqual(data['alert']['text'], 'sample-info')
+
     def test_custom_webhook(self):
 
         # setup custom webhook
@@ -841,11 +876,14 @@ class WebhooksTestCase(unittest.TestCase):
         custom_webhooks.webhooks['userdefined'] = DummyUserDefinedWebhook()
 
         # test json payload
-        response = self.client.post('/webhooks/json?foo=bar', json={'baz': 'quux'}, content_type='application/json')
+        response = self.client.post('/webhooks/json/bar/baz?foo=bar', json={'baz': 'quux'}, content_type='application/json')
         self.assertEqual(response.status_code, 201)
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(data['alert']['resource'], 'bar')
         self.assertEqual(data['alert']['event'], 'quux')
+        self.assertEqual(data['alert']['attributes']['path'], 'bar/baz')
+        self.assertEqual(data['alert']['attributes']['qs'], {'foo': 'bar'})
+        self.assertEqual(data['alert']['attributes']['data'], {'baz': 'quux'})
 
         # test text data
         response = self.client.post('/webhooks/text?foo', data='this is raw data', content_type='text/plain')
@@ -884,20 +922,45 @@ class WebhooksTestCase(unittest.TestCase):
         self.assertEqual(data['teapot'], True)
 
 
+class VmwareWebhook(WebhookBase):
+
+    def incoming(self, path, query_string, payload):
+        if payload['criticality'] == 'ALERT_CRITICALITY_LEVEL_WARNING':
+            severity = 'critical'
+        else:
+            severity = 'normal'
+        return Alert(
+            id=payload['alertId'],
+            resource=payload['resourceName'],
+            event=payload['subType'],
+            environment='Production',
+            service=[payload['resourceKind']],
+            severity=severity,
+            group=payload['resourceKind'],
+            type=payload['type'],
+            text=payload['info']
+        )
+
+
 class DummyJsonWebhook(WebhookBase):
 
-    def incoming(self, query_string, payload):
+    def incoming(self, path, query_string, payload):
         return Alert(
             resource=query_string['foo'],
             event=payload['baz'],
             environment='Production',
-            service=['Foo']
+            service=['Foo'],
+            attributes={
+                'path': path,
+                'qs': query_string,
+                'data': payload
+            }
         )
 
 
 class DummyTextWebhook(WebhookBase):
 
-    def incoming(self, query_string, payload):
+    def incoming(self, path, query_string, payload):
         return Alert(
             resource=query_string.get('foo') or 'nofoo',
             event=payload,
@@ -930,7 +993,7 @@ class DummyMultiPartFormWebhook(WebhookBase):
 
 class DummyUserDefinedWebhook(WebhookBase):
 
-    def incoming(self, query_string, payload):
+    def incoming(self, path, query_string, payload):
         return jsonify(
             status='ok',
             message='This is a test user-defined response',


### PR DESCRIPTION
Webhooks can now include subpaths. That is, if webhook is `/api/webhooks/sentry` then a subpath of  `sentry` will be accepted too. eg. `/api/webhooks/sentry/app/1/svc/9` and the path will be passed to the webhook handler for processing, if required.

New webhook method signature includes "path" ...
```
    def incoming(self, path: str, query_string: ImmutableMultiDict, payload: Any) -> Union[Alert, JSON]:
        """
        Parse webhook path, query string and/or payload in JSON or plain text and
        return an alert or a custom JSON response.
        """
        raise NotImplementedError
```

*References*
Add a REST Plug-In for vRealize Operations Manager Outbound Alerts - https://pubs.vmware.com/vrealizeoperationsmanager-6/index.jsp?topic=%2Fcom.vmware.vcom.core.doc%2FGUID-2A26A734-CD91-43E0-BF42-B079D5B0F5D4.html