### PR TITLE
Add "delete" hook called before any alert delete

### DIFF
--- a/alerta/plugins/__init__.py
+++ b/alerta/plugins/__init__.py
@@ -38,6 +38,10 @@ class PluginBase(metaclass=abc.ABCMeta):
         """Trigger integrations based on external actions. (optional)"""
         raise NotImplementedError
 
+    def delete(self, alert: 'Alert', **kwargs) -> bool:
+        """Trigger integrations when an alert is deleted. (optional)"""
+        raise NotImplementedError
+
     def get_config(self, key, default=None, type=None, **kwargs):
 
         if key in os.environ:

--- a/alerta/plugins/acked_by.py
+++ b/alerta/plugins/acked_by.py
@@ -35,3 +35,6 @@ class AckedBy(PluginBase):
         if action == 'unack':
             alert.attributes['acked-by'] = None
         return alert
+
+    def delete(self, alert, **kwargs) -> bool:
+        raise NotImplementedError

--- a/alerta/plugins/blackout.py
+++ b/alerta/plugins/blackout.py
@@ -41,3 +41,6 @@ class BlackoutHandler(PluginBase):
 
     def take_action(self, alert, action, text, **kwargs):
         raise NotImplementedError
+
+    def delete(self, alert, **kwargs) -> bool:
+        raise NotImplementedError

--- a/alerta/plugins/heartbeat.py
+++ b/alerta/plugins/heartbeat.py
@@ -35,3 +35,6 @@ class HeartbeatReceiver(PluginBase):
 
     def take_action(self, alert, action, text, **kwargs):
         raise NotImplementedError
+
+    def delete(self, alert, **kwargs) -> bool:
+        raise NotImplementedError

--- a/alerta/plugins/reject.py
+++ b/alerta/plugins/reject.py
@@ -47,3 +47,6 @@ class RejectPolicy(PluginBase):
 
     def take_action(self, alert, action, text, **kwargs):
         raise NotImplementedError
+
+    def delete(self, alert, **kwargs) -> bool:
+        raise NotImplementedError

--- a/alerta/plugins/remote_ip.py
+++ b/alerta/plugins/remote_ip.py
@@ -28,3 +28,6 @@ class RemoteIpAddr(PluginBase):
 
     def take_action(self, alert, action, text, **kwargs):
         raise NotImplementedError
+
+    def delete(self, alert, **kwargs) -> bool:
+        raise NotImplementedError

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -184,6 +184,27 @@ class PluginsTestCase(unittest.TestCase):
         self.assertEqual(data['alert']['history'][3]['text'],
                          'ticket resolved by bob (ticket #12345)-plugin1-plugin3', data['alert']['history'])
 
+    def test_delete(self):
+
+        plugins.plugins['delete1'] = CustDeletePlugin1()
+        plugins.plugins['delete2'] = CustDeletePlugin2()
+
+        # create alert
+        response = self.client.post('/alert', json=self.critical_alert, headers=self.headers)
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.data.decode('utf-8'))
+
+        alert_id = data['id']
+
+        # delete alert
+        response = self.client.delete('/alert/' + alert_id, headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data.decode('utf-8'))
+
+        # check deleted
+        response = self.client.get('/alert/' + alert_id)
+        self.assertEqual(response.status_code, 404)
+
     def test_heartbeat_alert(self):
 
         self.heartbeat_alert = {
@@ -304,3 +325,39 @@ class CustActionPlugin1(PluginBase):
             text = text + ' (ticket #12345)'
 
         return alert, action, text
+
+
+class CustDeletePlugin1(PluginBase):
+
+    def pre_receive(self, alert, **kwargs):
+        return alert
+
+    def post_receive(self, alert, **kwargs):
+        return
+
+    def status_change(self, alert, status, text, **kwargs):
+        return alert, status, text
+
+    def take_action(self, alert, action, text, **kwargs):
+        return alert, action, text
+
+    def delete(self, alert, **kwargs):
+        return True
+
+
+class CustDeletePlugin2(PluginBase):
+
+    def pre_receive(self, alert, **kwargs):
+        return alert
+
+    def post_receive(self, alert, **kwargs):
+        return
+
+    def status_change(self, alert, status, text, **kwargs):
+        return alert, status, text
+
+    def take_action(self, alert, action, text, **kwargs):
+        return alert, action, text
+
+    def delete(self, alert, **kwargs):
+        return True


### PR DESCRIPTION
Related to #1147 Federated Alerta.

A "forwarder" plugin might look like this ... (to be completed)
```
import logging

from alerta.plugins import PluginBase

LOG = logging.getLogger('alerta.plugins')


class Forwarder(PluginBase):
    """

    """

    def pre_receive(self, alert, **kwargs):
        return alert

    def post_receive(self, alert, **kwargs):
        # forward alert to other servers (last write wins)
        return

    def status_change(self, alert, status, text, **kwargs):
        # forward status changes to other servers
        return

    def take_action(self, alert, action, text, **kwargs):
        # trigger action on other servers
        pass

    def delete(self, alert, **kwargs) -> bool:
        # trigger delete on other servers
        # if remote delete succeed, return True, else False
        # if False, local delete is not actioned
        return True
```