### PR TITLE
Use OIDC and user roles

### DIFF
--- a/alerta/auth/oidc.py
+++ b/alerta/auth/oidc.py
@@ -136,7 +136,7 @@ def openid():
     else:
         user.update(login=login, email=email)
 
-    roles = custom_claims[role_claim] or user.roles
+    roles = custom_claims[role_claim] + user.roles
     groups = custom_claims[group_claim]
 
     if user.status != 'active':


### PR DESCRIPTION
When using OIDC authentication the defined user roles are not used anymore. Was this by accident or intentionally? This PR changes the behavior to use both role sources.