### PR TITLE
raise 401 api error if username neither contains @ nor '\\'

### DIFF
--- a/alerta/auth/basic_ldap.py
+++ b/alerta/auth/basic_ldap.py
@@ -27,14 +27,17 @@ def login():
     except KeyError:
         raise ApiError("must supply 'username' and 'password'", 401)
 
-    if '\\' in login:
-        domain, username = login.split('\\')
-        email = ''
-        email_verified = False
-    else:
-        username, domain = login.split('@')
-        email = login
-        email_verified = True
+    try: 
+        if '\\' in login:
+            domain, username = login.split('\\')
+            email = ''
+            email_verified = False
+        else:
+            username, domain = login.split('@')
+            email = login
+            email_verified = True
+    except ValueError:
+        raise ApiError("expected username with domain", 401)
 
     # Validate LDAP domain
     if domain not in current_app.config['LDAP_DOMAINS']:


### PR DESCRIPTION
### Current situation
Login with a username which does not contain the domain component using the ldap auth provider ends in a ValueError exception.

```
2020-04-01 07:10:00,871 flask.app[42]: [ERROR] not enough values to unpack (expected 2, got 1) request_id=da22f9d1-95f5-4c3e-b5cf-9ea13cf07b9c ip=10.50.0.27
Traceback (most recent call last):
  File "/venv/lib/python3.7/site-packages/flask/app.py", line 1813, in full_dispatch_request
    rv = self.dispatch_request()
  File "/venv/lib/python3.7/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/venv/lib/python3.7/site-packages/flask_cors/decorator.py", line 128, in wrapped_function
    resp = make_response(f(*args, **kwargs))
  File "/venv/lib/python3.7/site-packages/alerta/auth/basic_ldap.py", line 35, in login
    username, domain = login.split('@')
ValueError: not enough values to unpack (expected 2, got 1)
```

### Should
Throw a nicer exception which explains that the domain part is missing.

This minimal pr raises an ApiError if neither `domain\` nor `@domain` is given.