### PR TITLE
Auto-open timed-out acked alerts

### DIFF
--- a/alerta/models/enums.py
+++ b/alerta/models/enums.py
@@ -60,3 +60,22 @@ class Scope(str, Enum):
 
 
 ADMIN_SCOPES = [Scope.admin, Scope.read, Scope.write]
+
+
+class ChangeType(str, Enum):
+
+    open = 'open'
+    assign = 'assign'
+    ack = 'ack'
+    unack = 'unack'
+    shelve = 'shelve'
+    unshelve = 'unshelve'
+    close = 'close'
+
+    new = 'new'
+    action = 'action'
+    status = 'status'
+    value = 'value'
+    severity = 'severity'
+    timeout = 'timeout'
+    expired = 'expired'


### PR DESCRIPTION
Requires frontend changes to send `timeout` for ack'ed alerts and also to make that timeout a global setting and configurable per user. Same as for "shelve timeout" but the default would be "0" ie. do not auto-unack.