### PR TITLE
LDAP login improvements - Adding ldap search query.

### DIFF
--- a/alerta/auth/__init__.py
+++ b/alerta/auth/__init__.py
@@ -36,7 +36,7 @@ class AuthBlueprint(Blueprint):
 auth = AuthBlueprint('auth', __name__)
 
 
-from . import github, logout, oidc, userinfo   # noqa isort:skip
+from . import github, login, logout, oidc, userinfo   # noqa isort:skip
 
 
 @auth.before_request

--- a/alerta/auth/basic.py
+++ b/alerta/auth/basic.py
@@ -63,8 +63,6 @@ def signup():
     return jsonify(token=token.tokenize)
 
 
-@auth.route('/auth/login', methods=['OPTIONS', 'POST'])
-@cross_origin(supports_credentials=True)
 def login():
     # lookup user from username/email
     try:

--- a/alerta/auth/basic_ldap.py
+++ b/alerta/auth/basic_ldap.py
@@ -2,7 +2,6 @@ import sys
 
 import ldap  # pylint: disable=import-error
 from flask import current_app, jsonify, request
-from flask_cors import cross_origin
 
 from alerta.auth.utils import create_token, get_customers
 from alerta.exceptions import ApiError
@@ -10,11 +9,7 @@ from alerta.models.permission import Permission
 from alerta.models.user import User
 from alerta.utils.audit import auth_audit_trail
 
-from . import auth
 
-
-@auth.route('/auth/login', methods=['OPTIONS', 'POST'])
-@cross_origin(supports_credentials=True)
 def login():
     # Allow LDAP server to use a self signed certificate
     if current_app.config['LDAP_ALLOW_SELF_SIGNED_CERT']:
@@ -40,15 +35,61 @@ def login():
         raise ApiError('expected username with domain', 401)
 
     # Validate LDAP domain
-    if domain not in current_app.config['LDAP_DOMAINS']:
+    if domain not in current_app.config['LDAP_DOMAINS'] and \
+       domain not in current_app.config['LDAP_DOMAINS_SEARCH_QUERY']:
         raise ApiError('unauthorized domain', 403)
 
-    userdn = current_app.config['LDAP_DOMAINS'][domain] % username
-
-    # Attempt LDAP AUTH
+    # Initialise ldap connection
     try:
         trace_level = 2 if current_app.debug else 0
         ldap_connection = ldap.initialize(current_app.config['LDAP_URL'], trace_level=trace_level)
+    except Exception as e:
+        raise ApiError(str(e), 500)
+
+    # If user search filter exist
+    #   Search the user using the provided User Search filter for the current domain
+    #   If one user is found
+    #       Set the DN as the one found
+    #       Set email retreived from AD
+    #   If more than one user is found
+    #       Except: Search query is bad defined
+    # Else
+    #   Set the DN as the one found in LDAP_DOMAINS variable
+    domain_search_query = current_app.config.get('LDAP_DOMAINS_SEARCH_QUERY', {})
+    base_dns = current_app.config.get('LDAP_DOMAINS_BASEDN', {})
+    user_base_dn = current_app.config.get('LDAP_DOMAINS_USER_BASEDN', {})
+    if domain in domain_search_query:
+        ldap_bind_username = current_app.config.get('LDAP_BIND_USERNAME', '')
+        ldap_bind_password = current_app.config.get('LDAP_BIND_PASSWORD', '')
+
+        try:
+            ldap_connection.simple_bind_s(ldap_bind_username, ldap_bind_password)
+        except ldap.INVALID_CREDENTIALS:
+            raise ApiError('invalid ldap bind username or password', 401)
+
+        ldap_users = [(_dn, user) for _dn, user in ldap_connection.search_s(
+            base_dns[domain] if user_base_dn.get(domain) is None else user_base_dn[domain],
+            ldap.SCOPE_SUBTREE,
+            domain_search_query[domain].format(username=username, email=email),
+            ['mail']
+        ) if _dn is not None]
+
+        if len(ldap_users) > 1:
+            raise ApiError('invalid search query for domain "{}"'.format(domain), 500)
+        elif len(ldap_users) == 0:
+            raise ApiError('invalid username or password', 401)
+
+        for _dn, _email in ldap_users:
+            userdn = _dn
+            email_attr = _email.get('mail')
+            if email_attr is not None:
+                email = email_attr[0].decode(sys.stdout.encoding)
+                email_verified = True
+    else:
+        userdn = current_app.config['LDAP_DOMAINS'][domain] % username
+
+    # Attempt LDAP AUTH
+    try:
         ldap_connection.simple_bind_s(userdn, password)
     except ldap.INVALID_CREDENTIALS:
         raise ApiError('invalid username or password', 401)
@@ -78,17 +119,18 @@ def login():
     groups = list()
     try:
         groups_filters = current_app.config.get('LDAP_DOMAINS_GROUP', {})
-        base_dns = current_app.config.get('LDAP_DOMAINS_BASEDN', {})
-        if domain in groups_filters and domain in base_dns:
+        groups_base_dn = current_app.config.get('LDAP_DOMAINS_GROUP_BASEDN', {})
+        if domain in groups_filters and (domain in base_dns or domain in groups_base_dn):
             resultID = ldap_connection.search(
-                base_dns[domain],
+                base_dns[domain] if groups_base_dn.get(domain) is None else groups_base_dn[domain],
                 ldap.SCOPE_SUBTREE,
                 groups_filters[domain].format(username=username, email=email, userdn=userdn),
                 ['cn']
             )
             resultTypes, results = ldap_connection.result(resultID)
             for _dn, attributes in results:
-                groups.append(attributes['cn'][0].decode('utf-8'))
+                if _dn is not None:
+                    groups.append(attributes['cn'][0].decode('utf-8'))
     except ldap.LDAPError as e:
         raise ApiError(str(e), 500)
 

--- a/alerta/auth/login.py
+++ b/alerta/auth/login.py
@@ -1,0 +1,15 @@
+from flask import current_app
+from flask_cors import cross_origin
+
+from . import auth
+
+
+@auth.route('/auth/login', methods=['OPTIONS', 'POST'])
+@cross_origin(supports_credentials=True)
+def login():
+    if current_app.config['AUTH_PROVIDER'] == 'ldap':
+        from . import basic_ldap
+        return basic_ldap.login()
+    else:
+        from . import basic
+        return basic.login()

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -96,9 +96,14 @@ ALLOWED_GITLAB_GROUPS = None
 
 # BasicAuth using LDAP
 LDAP_URL = ''  # eg. ldap://localhost:389
+LDAP_BIND_USERNAME = ''  # Optional: Only needed if defined domain in LDAP_DOMAINS_SEARCH_QUERY. eg. uid=admin,ou=users,dc=domain,dc=com
+LDAP_BIND_PASSWORD = ''  # Optional: Only needed if defined domain in LDAP_DOMAINS_SEARCH_QUERY.
 LDAP_DOMAINS = {}  # type: Dict[str, str]
 LDAP_DOMAINS_GROUP = {}  # type: Dict[str, str]
 LDAP_DOMAINS_BASEDN = {}  # type: Dict[str, str]
+LDAP_DOMAINS_USER_BASEDN = {}  # type: Dict[str, str] # If not defined, it will take BASEDN
+LDAP_DOMAINS_GROUP_BASEDN = {}  # type: Dict[str, str] # If not defined, it will take BASEDN
+LDAP_DOMAINS_SEARCH_QUERY = {}  # type: Dict[str, str]
 LDAP_ALLOW_SELF_SIGNED_CERT = False
 
 # Microsoft Identity Platform (v2.0)

--- a/pylintrc
+++ b/pylintrc
@@ -165,7 +165,7 @@ ignore-mixin-members=yes
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set).
-ignored-classes=SQLObject
+ignored-classes=SQLObject,ldap
 
 # When zope mode is activated, add a predefined set of Zope acquired attributes
 # to generated-members.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ pylint==2.5.2
 pytest-cov
 pytest>=5.4.3
 python-dotenv
+python-ldap
 requests_mock
 twine
 wheel

--- a/tests/test_auth_ldap.py
+++ b/tests/test_auth_ldap.py
@@ -1,0 +1,157 @@
+import json
+import unittest
+from unittest.mock import patch
+
+import ldap
+
+from alerta.app import create_app, db
+from alerta.models.enums import Scope
+from alerta.models.key import ApiKey
+
+
+class AuthLdapTestCase(unittest.TestCase):
+
+    class LDAPObjectMock:
+        def __init__(self, user_to_login, pass_to_login, user_to_bind, pass_to_bind, search_results):
+            self.user_to_login = user_to_login
+            self.pass_to_login = pass_to_login
+            self.user_to_bind = user_to_bind
+            self.pass_to_bind = pass_to_bind
+            self.search_results = search_results
+
+        def simple_bind_s(self, who=None, cred=None, serverctrls=None, clientctrls=None):
+            # raise Exception("{}-{}......{}-{}".format(who, cred, self.user_to_bind, self.pass_to_bind))
+            if not((who == self.user_to_login and cred == self.pass_to_login)
+                   or (who == self.user_to_bind and cred == self.pass_to_bind)):
+                raise ldap.INVALID_CREDENTIALS
+            pass
+
+        def search_s(self, base, scope, filterstr=None, attrlist=None, attrsonly=0):
+            return self.search_results
+
+    def setUp(self):
+
+        test_config = {
+            'TESTING': True,
+            'DEBUG': True,
+            'AUTH_REQUIRED': True,
+            'AUTH_PROVIDER': 'ldap',
+            'CUSTOMER_VIEWS': True,
+            'ADMIN_USERS': ['admin@alerta.io'],
+            'LDAP_URL': 'ldap://myldap.server',
+            'LDAP_BIND_USERNAME': 'user_to_bind',
+            'LDAP_BIND_PASSWORD': 'password_to_bind',
+            'LDAP_DOMAINS_SEARCH_QUERY': {
+                'debeauharnais.fr': 'sAMAccountName={username}'
+            },
+            'LDAP_DOMAINS_USER_BASEDN': {
+                'debeauharnais.fr': ''
+            },
+            'LDAP_DOMAINS': {
+                'debeauharnais.fr': 'DN=%s'
+            }
+        }
+        self.app = create_app(test_config)
+        self.client = self.app.test_client()
+
+        with self.app.test_request_context('/'):
+            self.app.preprocess_request()
+            self.api_key = ApiKey(
+                user='admin@alerta.io',
+                scopes=[Scope.admin, Scope.read, Scope.write],
+                text='demo-key'
+            )
+            self.api_key.create()
+
+        self.headers = {
+            'Authorization': 'Key %s' % self.api_key.key,
+            'Content-type': 'application/json'
+        }
+
+    def tearDown(self):
+        db.destroy()
+
+    def test_401_error(self):
+
+        response = self.client.get('/alerts')
+        self.assertEqual(response.status_code, 401)
+
+    def test_ldap_login_defined_dn(self):
+
+        # Attemps to login with the defined DN instead of performing a search
+        self.app.config['LDAP_DOMAINS_SEARCH_QUERY'] = {}
+
+        mock_ldap = AuthLdapTestCase.LDAPObjectMock(
+            'DN=josephine',
+            'jojo',
+            'user_to_bind',
+            'password_to_bind',
+            [('DN=josephine', {'mail': [bytearray('josephine@debeauharnais.fr', 'utf-8')]})]
+        )
+
+        data = self.login_test(mock_ldap, 200)
+        self.assertIn('token', data)
+
+    def test_ldap_login_search(self):
+
+        mock_ldap = AuthLdapTestCase.LDAPObjectMock(
+            'DN=josephine',
+            'jojo',
+            'user_to_bind',
+            'password_to_bind',
+            [('DN=josephine', {'mail': [bytearray('josephine@debeauharnais.fr', 'utf-8')]})]
+        )
+
+        data = self.login_test(mock_ldap, 200)
+        self.assertIn('token', data)
+
+    def test_ldap_login_wrong_password(self):
+
+        mock_ldap = AuthLdapTestCase.LDAPObjectMock(
+            'DN=josephine',
+            'jojo_wrong',
+            'user_to_bind',
+            'password_to_bind',
+            [('DN=josephine', {'mail': [bytearray('josephine@debeauharnais.fr', 'utf-8')]})]
+        )
+
+        data = self.login_test(mock_ldap, 401)
+        self.assertIn('message', data)
+        self.assertEqual('invalid username or password', data.get('message'))
+
+    def test_ldap_login_wrong_bind_password(self):
+
+        mock_ldap = AuthLdapTestCase.LDAPObjectMock(
+            'DN=josephine',
+            'jojo',
+            'user_to_bind',
+            'password_to_bind_wrong',
+            [('DN=josephine', {'mail': [bytearray('josephine@debeauharnais.fr', 'utf-8')]})]
+        )
+
+        data = self.login_test(mock_ldap, 401)
+        self.assertIn('message', data)
+        self.assertEqual('invalid ldap bind username or password', data.get('message'))
+
+    def login_test(self, mock_ldap, expected_response_code):
+        # add customer mapping
+        payload = {
+            'customer': 'Bonaparte Industries',
+            'match': 'debeauharnais.fr'
+        }
+        response = self.client.post('/customer', data=json.dumps(payload),
+                                    content_type='application/json', headers=self.headers)
+        self.assertEqual(response.status_code, 201)
+        json.loads(response.data.decode('utf-8'))
+
+        payload = {
+            'email': 'josephine@debeauharnais.fr',
+            'password': 'jojo'
+        }
+
+        # login now that customer mapping exists
+        with patch('ldap.initialize', return_value=mock_ldap):
+            response = self.client.post('/auth/login', data=json.dumps(payload), content_type='application/json')
+            self.assertEqual(response.status_code, expected_response_code)
+
+        return json.loads(response.data.decode('utf-8'))

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
   requests_mock
   mongodb: pymongo
   postgres: psycopg2
+  python-ldap
 
 whitelist_externals =
   createdb


### PR DESCRIPTION
LDAP login improvements - Adding ldap search query. Instead of providing a fixed DN, a ldap search query can be provided to perform the user query and locate the DN

New properties added:
* LDAP_BIND_USERNAME: User DN to execute the LDAP Search query
* LDAP_BIND_PASSWORD: User DN password to execute the LDAP Search query
* LDAP_DOMAINS_USER_BASEDN: Base DN where to search for users, this variable has been created to have a better performance in the search user filter. If it is not defined, the Base DN will be used and the whole tree will be queried.
* LDAP_DOMAINS_GROUP_BASEDN: Base DN where to search for groups, this variable has been created to have a better performance in the search user filter. If it is not defined, the Base DN will be used and the whole tree will be queried.
* LDAP_DOMAINS_SEARCH_QUERY: Query to locate the user DN in the LDAP server. The query must return one entry. If there is no query defined for the current domain, the old system will happen and the static DN will be searched

Fixes #1172