### PR TITLE
Mongodb count_documents() is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Requirements
 The only mandatory dependency is MongoDB or PostgreSQL. Everything else is optional.
 
 - Postgres version 9.5 or better
-- MongoDB version 3.2 or better (4.0.7 required for full query syntax support)
+- MongoDB version 3.6 or better (4.0.7 required for full query syntax support)
 
 Installation
 ------------

--- a/alerta/database/backends/mongodb/base.py
+++ b/alerta/database/backends/mongodb/base.py
@@ -593,7 +593,7 @@ class Backend(Database):
         Return total number of alerts that meet the query filter.
         """
         query = query or Query()
-        return self.get_db().alerts.find(query.where).count()
+        return self.get_db().alerts.count_documents(query.where)
 
     def get_counts(self, query=None, group=None):
         query = query or Query()

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setuptools.setup(
         'Flask-Cors>=3.0.2',
         'mohawk',
         'PyJWT',
-        'pymongo>=3.0',
+        'pymongo>=3.6',
         'pyparsing',
         'python-dateutil',
         'pytz',


### PR DESCRIPTION
Replace `.count()` with `.count_documents()`

**References**
https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.count_documents

https://docs.mongodb.com/drivers/driver-compatibility-reference#python-driver-compatibility

Fixes #1196 