### PR TITLE
Include wsgi.py so flask CLI works

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,7 @@ include NOTICE
 include README.md
 exclude .gitignore
 global-exclude *.pyc
-include alerta/app.wsgi
+include wsgi.py
 include alerta/sql/schema.sql
 recursive-include alerta/templates *
 recursive-include alerta/static *


### PR DESCRIPTION
flask CLI was broken if Alerta server was installed using `pip` because `wsgi.py` wasn't included in the package.