### PR TITLE
Telegram(plugin/contrib) issue 309

### DIFF
--- a/alerta/webhooks/telegram.py
+++ b/alerta/webhooks/telegram.py
@@ -85,7 +85,10 @@ class TelegramWebhook(WebhookBase):
             elif action in ['watch', 'unwatch']:
                 alert.untag(tags=['{}:{}'.format(action, user)])
             elif action == 'blackout':
-                environment, resource, event = command.split('|', 2)
+                # new style paremeters: only alert_id
+                environment = alert.environment
+                resource = alert.resource
+                event = alert.event
                 blackout = Blackout(environment, resource=resource, event=event)
                 blackout.create()
 


### PR DESCRIPTION
This is the webhook part for contrib issue 309(https://github.com/alerta/alerta-contrib/issues/309).

The second commit(f73b21f) is a hack: send_message_reply needs alert_id, so this commit tries to parse it from /ack <alert_id>  command. If this backward compatability is not needed then I'd just ignore commit(f73b21f). (I think currently the telegram webhook /blackout command won't work at all (
 https://github.com/alerta/alerta/blob/master/alerta/webhooks/telegram.py#L88 tries to parse /blackout incorrecctly:
https://github.com/alerta/alerta/blob/master/alerta/webhooks/telegram.py#L75 splits callback_data to: command (/blackout), alert_id (Production|hostname.mycompany.com:9182|windows_low_memory)
https://github.com/alerta/alerta/blob/master/alerta/webhooks/telegram.py#L88 tries to split command again, I think L88 should split alert_id instead ? (splitting command in L88 results in ValueError?))
