### PR TITLE
End support for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: python
 cache: pip
 dist: xenial
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Alerta Release 7.0
+Alerta Release 8.0
 ==================
 
 [![Build Status](https://travis-ci.org/alerta/alerta.svg?branch=master)](https://travis-ci.org/alerta/alerta)
@@ -15,15 +15,10 @@ The Alerta monitoring tool was developed with the following aims in mind:
 
 ----
 
-Python 2.7 support is EOL
--------------------------
-
-Starting with Release 6.0 only Python 3.5+ is supported. Release 5.2 was the
-last to support Python 2.7 and feature enhancements for this release ended on
-August 31, 2018. Only critical bug fixes will be backported to Release 5.2.
-
 Requirements
 ------------
+
+Release 8 only supports Python 3.6 or higher.
 
 The only mandatory dependency is MongoDB or PostgreSQL. Everything else is optional.
 

--- a/setup.py
+++ b/setup.py
@@ -100,8 +100,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.5',
         'Topic :: System :: Monitoring',
     ],
-    python_requires='>=3.5'
+    python_requires='>=3.6'
 )


### PR DESCRIPTION
Python 3.5 is end-of-life in less than three months (13/09/2020) so remove support in Release 8.

<img width="742" alt="Screenshot 2020-06-22 at 19 59 04" src="https://user-images.githubusercontent.com/615057/85320121-df3a0c80-b4c2-11ea-8978-b4066305d85f.png">

https://endoflife.date/python