### PR TITLE
Add font settings for web UI

### DIFF
--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -202,6 +202,13 @@ ASI_QUERIES = [
     {'text': 'Misc.', 'query': 'group=Misc'},
 ]
 
+# Alarm list default font settings
+DEFAULT_FONT = {
+    'font-family': '"Sintony", Arial, sans-serif',
+    'font-size': '13px',
+    'font-weight': 500  # 400=normal, 700=bold
+}
+
 # List of custom actions
 ACTIONS = []  # type: List[str]
 GOOGLE_TRACKING_ID = None

--- a/alerta/views/config.py
+++ b/alerta/views/config.py
@@ -50,6 +50,7 @@ def config():
             'mediumDate': current_app.config['DATE_FORMAT_MEDIUM_DATE'],
             'longDate': current_app.config['DATE_FORMAT_LONG_DATE']
         },
+        'font': current_app.config['DEFAULT_FONT'],
         'audio': {
             'new': current_app.config['DEFAULT_AUDIO_FILE']
         },


### PR DESCRIPTION
See alerta/alerta-webui#357

*Example*
```
DEFAULT_FONT = {
    'font-family': '"B612", "Fira Code", sans-serif',
    'font-size': '22px',
    'font-weight': 600  # 400=normal, 700=bold
}
```