### PR TITLE
Allow custom resource IDs on all resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,9 @@ ENV/
 env.bak/
 venv.bak/
 
+data/
+pg-data/
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/alerta/models/alert.py
+++ b/alerta/models/alert.py
@@ -46,7 +46,7 @@ class Alert:
         if timeout < 0:
             raise ValueError("Invalid negative 'timeout' value ({})".format(timeout))
 
-        self.id = kwargs.get('id', None) or str(uuid4())
+        self.id = kwargs.get('id') or str(uuid4())
         self.resource = resource
         self.event = event
         self.environment = kwargs.get('environment', None) or ''

--- a/alerta/models/blackout.py
+++ b/alerta/models/blackout.py
@@ -26,7 +26,7 @@ class Blackout:
             duration = kwargs.get('duration', None) or current_app.config['BLACKOUT_DURATION']
             end_time = start_time + timedelta(seconds=duration)
 
-        self.id = kwargs.get('id', str(uuid4()))
+        self.id = kwargs.get('id') or str(uuid4())
         self.environment = environment
         self.service = kwargs.get('service', None) or list()
         self.resource = kwargs.get('resource', None)
@@ -76,6 +76,7 @@ class Blackout:
             raise ValueError('tags must be a list')
 
         return Blackout(
+            id=json.get('id', None),
             environment=json['environment'],
             service=json.get('service', list()),
             resource=json.get('resource', None),

--- a/alerta/models/customer.py
+++ b/alerta/models/customer.py
@@ -12,13 +12,14 @@ class Customer:
 
     def __init__(self, match: str, customer: str, **kwargs) -> None:
 
-        self.id = kwargs.get('id', str(uuid4()))
+        self.id = kwargs.get('id') or str(uuid4())
         self.match = match
         self.customer = customer
 
     @classmethod
     def parse(cls, json: JSON) -> 'Customer':
         return Customer(
+            id=json.get('id', None),
             match=json.get('match', None),
             customer=json.get('customer', None)
         )

--- a/alerta/models/group.py
+++ b/alerta/models/group.py
@@ -72,7 +72,7 @@ class Group:
         if not name:
             raise ValueError('Missing mandatory value for name')
 
-        self.id = kwargs.get('id', str(uuid4()))
+        self.id = kwargs.get('id') or str(uuid4())
         self.name = name
         self.text = text or ''
         self.count = kwargs.get('count')
@@ -80,6 +80,7 @@ class Group:
     @classmethod
     def parse(cls, json: JSON) -> 'Group':
         return Group(
+            id=json.get('id', None),
             name=json.get('name', None),
             text=json.get('text', None)
         )

--- a/alerta/models/heartbeat.py
+++ b/alerta/models/heartbeat.py
@@ -40,7 +40,7 @@ class Heartbeat:
         if timeout < 0:
             raise ValueError("Invalid negative 'max_latency' value ({})".format(timeout))
 
-        self.id = kwargs.get('id', str(uuid4()))
+        self.id = kwargs.get('id') or str(uuid4())
         self.origin = origin or '{}/{}'.format(os.path.basename(sys.argv[0]), platform.uname()[1])
         self.tags = tags or list()
         self.attributes = kwargs.get('attributes', None) or dict()
@@ -81,6 +81,7 @@ class Heartbeat:
             raise ValueError('customer must not be an empty string')
 
         return Heartbeat(
+            id=json.get('id', None),
             origin=json.get('origin', None),
             tags=json.get('tags', list()),
             attributes=json.get('attributes', dict()),

--- a/alerta/models/key.py
+++ b/alerta/models/key.py
@@ -15,7 +15,7 @@ class ApiKey:
 
     def __init__(self, user: str, scopes: List[Scope], text: str = '', expire_time: datetime = None, customer: str = None, **kwargs) -> None:
 
-        self.id = kwargs.get('id', None) or str(uuid4())
+        self.id = kwargs.get('id') or str(uuid4())
         self.key = kwargs.get('key', None) or key_helper.generate()
         self.user = user
         self.scopes = scopes or key_helper.user_default_scopes
@@ -35,6 +35,7 @@ class ApiKey:
             raise ValueError('scopes must be a list')
 
         api_key = ApiKey(
+            id=json.get('id', None),
             user=json.get('user', None),
             scopes=[Scope(s) for s in json.get('scopes', [])],
             text=json.get('text', None),

--- a/alerta/models/note.py
+++ b/alerta/models/note.py
@@ -18,7 +18,7 @@ class Note:
 
     def __init__(self, text: str, user: str, note_type: str, **kwargs) -> None:
 
-        self.id = kwargs.get('id', str(uuid4()))
+        self.id = kwargs.get('id') or str(uuid4())
         self.text = text
         self.user = user
         self.note_type = note_type
@@ -31,6 +31,7 @@ class Note:
     @classmethod
     def parse(cls, json: JSON) -> 'Note':
         return Note(
+            id=json.get('id', None),
             text=json.get('status', None),
             user=json.get('status', None),
             attributes=json.get('attributes', dict()),
@@ -52,11 +53,13 @@ class Note:
             'type': self.note_type,
             'createTime': self.create_time,
             'updateTime': self.update_time,
-            'related': dict(),
+            '_links': dict(),
             'customer': self.customer
         }
         if self.alert:
-            note['related']['alert'] = self.alert
+            note['_links'] = {
+                'alert': absolute_url('/alert/' + self.alert)
+            }
         return note
 
     def __repr__(self) -> str:

--- a/alerta/models/permission.py
+++ b/alerta/models/permission.py
@@ -13,7 +13,7 @@ class Permission:
 
     def __init__(self, match: str, scopes: List[Scope], **kwargs) -> None:
 
-        self.id = kwargs.get('id', str(uuid4()))
+        self.id = kwargs.get('id') or str(uuid4())
         self.match = match
         self.scopes = scopes or list()
 
@@ -23,6 +23,7 @@ class Permission:
             raise ValueError('scopes must be a list')
 
         return Permission(
+            id=json.get('id', None),
             match=json.get('match', None),
             scopes=[Scope(s) for s in json.get('scopes', list())]
         )

--- a/alerta/models/user.py
+++ b/alerta/models/user.py
@@ -23,7 +23,7 @@ class User:
         if not login:
             raise ValueError('Missing mandatory value for "login"')
 
-        self.id = kwargs.get('id', None) or str(uuid4())
+        self.id = kwargs.get('id') or str(uuid4())
         self.name = name or ''
         self.login = login  # => g.login
         self.password = password  # NB: hashed password
@@ -54,6 +54,7 @@ class User:
     @classmethod
     def parse(cls, json: JSON) -> 'User':
         return User(
+            id=json.get('id', None),
             name=json['name'],
             login=json.get('login', None) or json.get('email', None),
             password=utils.generate_password_hash(json.get('password', '')),

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -136,7 +136,7 @@ class AlertNotesTestCase(unittest.TestCase):
         self.assertEqual(data['note']['type'], 'alert')
         self.assertIsNotNone(data['note']['createTime'])
         self.assertIsNone(data['note']['updateTime'])
-        self.assertEqual(data['note']['related']['alert'], alert_id)
+        self.assertIn(alert_id, data['note']['_links']['alert'])
         self.assertEqual(data['note']['customer'], None)
 
         # list notes for alert
@@ -167,7 +167,7 @@ class AlertNotesTestCase(unittest.TestCase):
         self.assertEqual(data['note']['type'], 'alert')
         self.assertIsNotNone(data['note']['createTime'])
         self.assertIsNotNone(data['note']['updateTime'])
-        self.assertEqual(data['note']['related']['alert'], alert_id)
+        self.assertIn(alert_id, data['note']['_links']['alert'])
         self.assertEqual(data['note']['customer'], None)
 
         # list notes for alert (again)


### PR DESCRIPTION
**Example**

```
$ http -v :8080/blackout id=bo1 environment=Development
POST /blackout HTTP/1.1
Accept: application/json, */*;q=0.5
Accept-Encoding: gzip, deflate
Connection: keep-alive
Content-Length: 43
Content-Type: application/json
Host: localhost:8080
User-Agent: HTTPie/2.1.0

{
    "environment": "Development",
    "id": "bo1"
}

HTTP/1.0 201 CREATED
Access-Control-Allow-Origin: http://localhost
Content-Encoding: gzip
Content-Length: 269
Content-Type: application/json
Date: Sun, 05 Jul 2020 14:18:33 GMT
Location: http://localhost:8080/blackout/bo1
Server: Werkzeug/1.0.1 Python/3.7.3
Vary: Origin, Accept-Encoding
X-Request-ID: eb49978c-94d1-4757-a55d-16e4e43f3b26

{
    "blackout": {
        "createTime": "2020-07-05T14:18:33.211Z",
        "customer": null,
        "duration": 3600,
        "endTime": "2020-07-05T15:18:33.211Z",
        "environment": "Development",
        "event": null,
        "group": null,
        "href": "http://localhost:8080/blackout/bo1",
        "id": "bo1",
        "priority": 1,
        "remaining": 3599,
        "resource": null,
        "service": [],
        "startTime": "2020-07-05T14:18:33.211Z",
        "status": "active",
        "tags": [],
        "text": null,
        "user": null
    },
    "id": "bo1",
    "status": "ok"
}
```

Fixes #1266 