### PR TITLE
Fix CloudWatch webhook bug

### DIFF
--- a/alerta/webhooks/cloudwatch.py
+++ b/alerta/webhooks/cloudwatch.py
@@ -52,9 +52,13 @@ class CloudWatchWebhook(WebhookBase):
             if 'Trigger' not in alarm:
                 raise ValueError('SNS message is not a Cloudwatch notification')
 
+            resource = notification['TopicArn'].split(':')[-1]
+            if alarm['Trigger']['Dimensions']:
+              resource = '{}:{}'.format(alarm['Trigger']['Dimensions'][0]['name'],
+                                        alarm['Trigger']['Dimensions'][0]['value'])
+
             return Alert(
-                resource='{}:{}'.format(alarm['Trigger']['Dimensions'][0]['name'],
-                                        alarm['Trigger']['Dimensions'][0]['value']),
+                resource=resource,
                 event=alarm['AlarmName'],
                 environment='Production',
                 severity=self.cw_state_to_severity(alarm['NewStateValue']),


### PR DESCRIPTION
If `Dimensions` list is empty alert is never going to be shown on the Alerta dashboard and this is definitely not a desired behaviour.
By making this change if `Dimensions` list is empty value for `resource` variable will be set to topic name and alert will be shown on the Alerta dashboard.