### PR TITLE
[Enhancement] Ability to use tags in Pingdom to set 'environment' and 'group' of alert

### DIFF
--- a/alerta/webhooks/pingdom.py
+++ b/alerta/webhooks/pingdom.py
@@ -29,7 +29,7 @@ class PingdomWebhook(WebhookBase):
             severity = alarm_model.DEFAULT_NORMAL_SEVERITY
 
         if len(payload['tags']) > 0:
-            tags_dict = { d[0].strip():d[1].strip() for d in [ t.split('_') for t in payload['tags'] if '_' in t ] }
+            tags_dict = { d[0].strip():d[1].strip() for d in [ t.split('_') for t in payload['tags'] if '_' in t ] if len(d[0]) > 0 and len(d[1]) > 0 }
 
             if 'environment' in tags_dict:
                 environment = tags_dict['environment']

--- a/alerta/webhooks/pingdom.py
+++ b/alerta/webhooks/pingdom.py
@@ -29,7 +29,7 @@ class PingdomWebhook(WebhookBase):
             severity = alarm_model.DEFAULT_NORMAL_SEVERITY
 
         if len(payload['tags']) > 0:
-            tags_dict = { d[0].strip():d[1].strip() for d in [ t.split(':') for t in payload['tags'] if ':' in t ] }
+            tags_dict = { d[0].strip():d[1].strip() for d in [ t.split('_') for t in payload['tags'] if '_' in t ] }
 
             if 'environment' in tags_dict:
                 environment = tags_dict['environment']

--- a/alerta/webhooks/pingdom.py
+++ b/alerta/webhooks/pingdom.py
@@ -29,7 +29,7 @@ class PingdomWebhook(WebhookBase):
             severity = alarm_model.DEFAULT_NORMAL_SEVERITY
 
         if len(payload['tags']) > 0:
-            tags_dict = { d[0].strip():d[1].strip() for d in [ t.split('_') for t in payload['tags'] if '_' in t ] if len(d[0]) > 0 and len(d[1]) > 0 }
+            tags_dict = {d[0].strip(): d[1].strip() for d in [t.split('_') for t in payload['tags'] if '_' in t] if len(d[0]) > 0 and len(d[1]) > 0}
 
             if 'environment' in tags_dict:
                 environment = tags_dict['environment']

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -824,7 +824,7 @@ class WebhooksTestCase(unittest.TestCase):
         self.assertEqual(data['alert']['text'], 'HIGH: HTTP Server Error 503 Service Unavailable')
         self.assertEqual(data['alert']['value'], 'HTTP Error 503')
         self.assertEqual(data['alert']['tags'], ['environment_staging', 'group_mainsite'])
-        self.assertEqual(data['alert']['environment'], 'staging')
+        self.assertEqual(data['alert']['environment'].capitalize(), 'Staging')
         self.assertEqual(data['alert']['group'], 'mainsite')
 
         # http up
@@ -837,7 +837,7 @@ class WebhooksTestCase(unittest.TestCase):
         self.assertEqual(data['alert']['text'], 'HIGH: OK')
         self.assertEqual(data['alert']['value'], 'OK')
         self.assertEqual(data['alert']['tags'], ['environment_staging', 'group_mainsite'])
-        self.assertEqual(data['alert']['environment'], 'staging')
+        self.assertEqual(data['alert']['environment'].capitalize(), 'Staging')
         self.assertEqual(data['alert']['group'], 'mainsite')
 
     def test_prometheus_webhook(self):

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -368,7 +368,7 @@ class WebhooksTestCase(unittest.TestCase):
                     "location": "Strasbourg 5, France",
                     "ipv6": ""
                 },
-                "tags": [],
+                "tags": ["environment_stage", "group_mainsite"],
                 "check_id": 803318,
                 "current_state": "DOWN",
                 "check_params": {
@@ -823,6 +823,9 @@ class WebhooksTestCase(unittest.TestCase):
         self.assertEqual(data['alert']['severity'], 'critical')
         self.assertEqual(data['alert']['text'], 'HIGH: HTTP Server Error 503 Service Unavailable')
         self.assertEqual(data['alert']['value'], 'HTTP Error 503')
+        self.assertEqual(data['alert']['tags'], ['environment_stage', 'group_mainsite'])
+        self.assertEqual(data['alert']['environment'], 'stage')
+        self.assertEqual(data['alert']['group'], 'mainsite')
 
         # http up
         response = self.client.post('/webhooks/pingdom', data=self.pingdom_up, headers=self.headers)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -368,7 +368,7 @@ class WebhooksTestCase(unittest.TestCase):
                     "location": "Strasbourg 5, France",
                     "ipv6": ""
                 },
-                "tags": ["environment_stage", "group_mainsite"],
+                "tags": ["environment_staging", "group_mainsite"],
                 "check_id": 803318,
                 "current_state": "DOWN",
                 "check_params": {
@@ -401,7 +401,7 @@ class WebhooksTestCase(unittest.TestCase):
                     "location": "Athens, Greece",
                     "ipv6": ""
                 },
-                "tags": [],
+                "tags": ["environment_staging", "group_mainsite"],
                 "check_id": 803318,
                 "current_state": "UP",
                 "check_params": {
@@ -823,8 +823,8 @@ class WebhooksTestCase(unittest.TestCase):
         self.assertEqual(data['alert']['severity'], 'critical')
         self.assertEqual(data['alert']['text'], 'HIGH: HTTP Server Error 503 Service Unavailable')
         self.assertEqual(data['alert']['value'], 'HTTP Error 503')
-        self.assertEqual(data['alert']['tags'], ['environment_stage', 'group_mainsite'])
-        self.assertEqual(data['alert']['environment'], 'stage')
+        self.assertEqual(data['alert']['tags'], ['environment_staging', 'group_mainsite'])
+        self.assertEqual(data['alert']['environment'], 'staging')
         self.assertEqual(data['alert']['group'], 'mainsite')
 
         # http up
@@ -836,6 +836,9 @@ class WebhooksTestCase(unittest.TestCase):
         self.assertEqual(data['alert']['severity'], 'normal')
         self.assertEqual(data['alert']['text'], 'HIGH: OK')
         self.assertEqual(data['alert']['value'], 'OK')
+        self.assertEqual(data['alert']['tags'], ['environment_staging', 'group_mainsite'])
+        self.assertEqual(data['alert']['environment'], 'staging')
+        self.assertEqual(data['alert']['group'], 'mainsite')
 
     def test_prometheus_webhook(self):
 


### PR DESCRIPTION
To change `environment` of alert triggered by a Pingdom webhook add the tag `environment_YourEnvironment` to the check, and `environment` gets set to `yourenvironment` (Pingdom changes uppercase to lowercase).

To change `group` of the alert triggered by a Pingdom webhook add the tag `group_YourGroupName` to the check, and `group` gets set to `yourgroupname` (Pingdom changes uppercase to lowercase).