### PR TITLE
Use guest scope as default

### DIFF
--- a/alerta/database/backends/mongodb/base.py
+++ b/alerta/database/backends/mongodb/base.py
@@ -1498,7 +1498,7 @@ class Backend(Database):
             response = self.get_db().perms.find_one({'match': match}, projection={'scopes': 1, '_id': 0})
             if response:
                 scopes.extend(response['scopes'])
-        return sorted(set(scopes)) or current_app.config['USER_DEFAULT_SCOPES']
+        return sorted(set(scopes)) or current_app.config['GUEST_DEFAULT_SCOPES']
 
     # CUSTOMERS
 

--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -1144,7 +1144,7 @@ class Backend(Database):
             response = self._fetchone(select, (match,))
             if response:
                 scopes.extend(response.scopes)
-        return sorted(set(scopes)) or current_app.config['USER_DEFAULT_SCOPES']
+        return sorted(set(scopes)) or current_app.config['GUEST_DEFAULT_SCOPES']
 
     # CUSTOMERS
 


### PR DESCRIPTION
Currently the default scope of a new user is `user`.

This is not ideal when using `oidc` (and maybe also others) as auth because the user gets created with first login attempt. So the user has maybe more rights than desired.

With this change the default scope is changed to `guest`.