### PR TITLE
Do not allow LDAP login with empty password

### DIFF
--- a/alerta/auth/basic_ldap.py
+++ b/alerta/auth/basic_ldap.py
@@ -27,6 +27,9 @@ def login():
     except KeyError:
         raise ApiError("must supply 'username' and 'password'", 401)
 
+    if not password:
+        raise ApiError('password not allowed to be empty', 401)
+
     try:
         if '\\' in login:
             domain, username = login.split('\\')

--- a/alerta/models/note.py
+++ b/alerta/models/note.py
@@ -55,7 +55,7 @@ class Note:
             'updateTime': self.update_time,
             '_links': dict(),
             'customer': self.customer
-        }
+        }  # type: Dict[str, Any]
         if self.alert:
             note['_links'] = {
                 'alert': absolute_url('/alert/' + self.alert)


### PR DESCRIPTION
```
(venv) ➜  python-alerta-client git:(master) http -v :8080/auth/login username=foo password=
POST /auth/login HTTP/1.1
Accept: application/json, */*;q=0.5
Accept-Encoding: gzip, deflate
Connection: keep-alive
Content-Length: 35
Content-Type: application/json
Host: localhost:8080
User-Agent: HTTPie/2.1.0

{
    "password": "",
    "username": "foo"
}

HTTP/1.0 401 UNAUTHORIZED
Access-Control-Allow-Origin: http://localhost
Content-Length: 131
Content-Type: application/json
Date: Sat, 24 Oct 2020 20:31:10 GMT
Server: Werkzeug/1.0.1 Python/3.7.3
Vary: Origin
X-Request-ID: 06eefaf8-1716-49de-998f-e3c05f59292e

{
    "code": 401,
    "errors": null,
    "message": "password not allowed to be empty",
    "requestId": null,
    "status": "error"
}
```

Fixes #1277