### PR TITLE
Support user-defined list of user roles

### DIFF
--- a/alerta/auth/basic.py
+++ b/alerta/auth/basic.py
@@ -23,7 +23,7 @@ def signup():
         raise ApiError(str(e), 400)
 
     # set sign-up defaults
-    user.roles = ['user']
+    user.roles = current_app.config['USER_ROLES']
     user.email_verified = False
 
     # check allowed domain

--- a/alerta/auth/basic_ldap.py
+++ b/alerta/auth/basic_ldap.py
@@ -71,7 +71,7 @@ def login():
     user = User.find_by_username(username=login)
     if not user:
         user = User(name=username, login=login, password='', email=email,
-                    roles=[], text='LDAP user', email_verified=email_verified)
+                    roles=current_app.config['USER_ROLES'], text='LDAP user', email_verified=email_verified)
         try:
             user = user.create()
         except Exception as e:

--- a/alerta/auth/github.py
+++ b/alerta/auth/github.py
@@ -58,7 +58,7 @@ def github():
     user = User.find_by_id(id=subject)
     if not user:
         user = User(id=subject, name=name, login=login, password='', email=email,
-                    roles=[], text='', email_verified=email_verified)
+                    roles=current_app.config['USER_ROLES'], text='', email_verified=email_verified)
         user.create()
     else:
         user.update(login=login, email=email)

--- a/alerta/auth/oidc.py
+++ b/alerta/auth/oidc.py
@@ -131,7 +131,7 @@ def openid():
     user = User.find_by_id(id=subject)
     if not user:
         user = User(id=subject, name=name, login=login, password='', email=email,
-                    roles=[], text='', email_verified=email_verified)
+                    roles=current_app.config['USER_ROLES'], text='', email_verified=email_verified)
         user.create()
     else:
         user.update(login=login, email=email)

--- a/alerta/auth/saml.py
+++ b/alerta/auth/saml.py
@@ -87,7 +87,7 @@ def saml_response_from_idp():
     user = User.find_by_username(username=email)
     if not user:
         user = User(name=name, login=login, password='', email=email,
-                    roles=[], text='SAML2 user', email_verified=True)
+                    roles=current_app.config['USER_ROLES'], text='SAML2 user', email_verified=True)
         try:
             user = user.create()
         except Exception as e:

--- a/alerta/commands.py
+++ b/alerta/commands.py
@@ -11,7 +11,6 @@ from alerta.auth.utils import generate_password_hash
 from alerta.models.enums import Scope
 from alerta.models.key import ApiKey
 from alerta.models.user import User
-from alerta.settings import DEFAULT_ADMIN_ROLE
 from alerta.version import __version__
 
 
@@ -172,7 +171,7 @@ def user(name, email, password, text, all):
             name=name or login,
             login=login,
             password=generate_password_hash(password),
-            roles=[DEFAULT_ADMIN_ROLE],
+            roles=current_app.config['ADMIN_ROLES'],
             text=text,
             email=email,
             email_verified=bool(email)

--- a/alerta/database/backends/mongodb/base.py
+++ b/alerta/database/backends/mongodb/base.py
@@ -1491,14 +1491,14 @@ class Backend(Database):
         for match in matches:
             if match in current_app.config['ADMIN_ROLES']:
                 return ADMIN_SCOPES
-            if match == 'user':
+            if match in current_app.config['USER_ROLES']:
                 scopes.extend(current_app.config['USER_DEFAULT_SCOPES'])
-            if match == 'guest':
+            if match in current_app.config['GUEST_ROLES']:
                 scopes.extend(current_app.config['GUEST_DEFAULT_SCOPES'])
             response = self.get_db().perms.find_one({'match': match}, projection={'scopes': 1, '_id': 0})
             if response:
                 scopes.extend(response['scopes'])
-        return sorted(set(scopes)) or current_app.config['USER_DEFAULT_SCOPES']
+        return sorted(set(scopes))
 
     # CUSTOMERS
 

--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -1136,15 +1136,15 @@ class Backend(Database):
         for match in matches:
             if match in current_app.config['ADMIN_ROLES']:
                 return ADMIN_SCOPES
-            if match == 'user':
+            if match in current_app.config['USER_ROLES']:
                 scopes.extend(current_app.config['USER_DEFAULT_SCOPES'])
-            if match == 'guest':
+            if match in current_app.config['GUEST_ROLES']:
                 scopes.extend(current_app.config['GUEST_DEFAULT_SCOPES'])
             select = """SELECT scopes FROM perms WHERE match=%s"""
             response = self._fetchone(select, (match,))
             if response:
                 scopes.extend(response.scopes)
-        return sorted(set(scopes)) or current_app.config['USER_DEFAULT_SCOPES']
+        return sorted(set(scopes))
 
     # CUSTOMERS
 

--- a/alerta/models/user.py
+++ b/alerta/models/user.py
@@ -8,7 +8,6 @@ from alerta.app import db
 from alerta.auth import utils
 from alerta.database.base import Query
 from alerta.models.group import Group
-from alerta.settings import DEFAULT_ADMIN_ROLE
 from alerta.utils.response import absolute_url
 
 JSON = Dict[str, Any]
@@ -29,7 +28,7 @@ class User:
         self.password = password  # NB: hashed password
         self.email = email
         self.status = kwargs.get('status', None) or 'active'  # 'active', 'inactive', 'unknown'
-        self.roles = [DEFAULT_ADMIN_ROLE] if self.email and self.email in current_app.config['ADMIN_USERS'] else (roles or ['user'])
+        self.roles = current_app.config['ADMIN_ROLES'] if self.email and self.email in current_app.config['ADMIN_USERS'] else roles
         self.attributes = kwargs.get('attributes', None) or dict()
         self.create_time = kwargs.get('create_time', None) or datetime.utcnow()
         self.last_login = kwargs.get('last_login', None)

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -62,7 +62,11 @@ AUTH_PROVIDER = 'basic'  # basic (default), ldap, github, openid, saml2, azure, 
 ADMIN_USERS = []  # type: List[str]
 DEFAULT_ADMIN_ROLE = 'admin'
 ADMIN_ROLES = [DEFAULT_ADMIN_ROLE]
+DEFAULT_USER_ROLE = 'user'
+USER_ROLES = [DEFAULT_USER_ROLE]
 USER_DEFAULT_SCOPES = ['read', 'write']  # Note: 'write' scope implicitly includes 'read'
+DEFAULT_GUEST_ROLE = 'guest'
+GUEST_ROLES = [DEFAULT_GUEST_ROLE]
 GUEST_DEFAULT_SCOPES = ['read:alerts']
 CUSTOMER_VIEWS = False
 

--- a/alerta/views/permissions.py
+++ b/alerta/views/permissions.py
@@ -4,9 +4,8 @@ from flask_cors import cross_origin
 from alerta.app import qb
 from alerta.auth.decorators import permission
 from alerta.exceptions import ApiError
-from alerta.models.enums import Scope
+from alerta.models.enums import ADMIN_SCOPES, Scope
 from alerta.models.permission import Permission
-from alerta.settings import DEFAULT_ADMIN_ROLE
 from alerta.utils.audit import admin_audit_trail
 from alerta.utils.response import jsonp
 
@@ -23,7 +22,11 @@ def create_perm():
     except ValueError as e:
         raise ApiError(str(e), 400)
 
-    if perm.match in [DEFAULT_ADMIN_ROLE, 'user', 'guest']:
+    if perm.match in [
+        current_app.config['DEFAULT_ADMIN_ROLE'],
+        current_app.config['DEFAULT_USER_ROLE'],
+        current_app.config['DEFAULT_GUEST_ROLE']
+    ]:
         raise ApiError('{} role already exists'.format(perm.match), 409)
 
     for want_scope in perm.scopes:
@@ -67,15 +70,15 @@ def list_perms():
     perms = Permission.find_all(query)
 
     admin_perm = Permission(
-        match=DEFAULT_ADMIN_ROLE,
-        scopes=[Scope.admin]
+        match=current_app.config['DEFAULT_ADMIN_ROLE'],
+        scopes=ADMIN_SCOPES
     )
     user_perm = Permission(
-        match='user',
+        match=current_app.config['DEFAULT_USER_ROLE'],
         scopes=current_app.config['USER_DEFAULT_SCOPES']
     )
     guest_perm = Permission(
-        match='guest',
+        match=current_app.config['DEFAULT_GUEST_ROLE'],
         scopes=current_app.config['GUEST_DEFAULT_SCOPES']
     )
 

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -16,7 +16,9 @@ class ScopesTestCase(unittest.TestCase):
             'AUTH_REQUIRED': True,
             'ADMIN_USERS': ['admin@alerta.io', 'sys@alerta.io'],
             'DEFAULT_ADMIN_ROLE': 'ops',
-            'ADMIN_ROLES': ['ops', 'devops']
+            'ADMIN_ROLES': ['ops', 'devops'],
+            'DEFAULT_USER_ROLE': 'dev',
+            'USER_ROLES': ['dev']
         }
         self.app = create_app(test_config, environment='development')
         self.client = self.app.test_client()


### PR DESCRIPTION
Add config option to allow Alerta admins to set the default roles for users when they log in for the first time.

**Defaults**
```
DEFAULT_USER_ROLE = 'user'
USER_ROLES = [DEFAULT_USER_ROLE]
```
For example, to set default user role to "very-limited-role" ...
```
DEFAULT_USER_ROLE = 'very-limited-role'
USER_ROLES = [DEFAULT_USER_ROLE]
```
or to nothing ...
```
USER_ROLES = []
```

See also #1148