### PR TITLE
Hide fields with large data from default alerts response

### DIFF
--- a/alerta/database/backends/mongodb/utils.py
+++ b/alerta/database/backends/mongodb/utils.py
@@ -90,9 +90,9 @@ class QueryBuilderImpl(QueryBuilder):
             query['$or'] = [{'_id': {'$regex': re.compile('|'.join(['^' + i for i in ids]))}},
                             {'lastReceiveId': {'$regex': re.compile('|'.join(['^' + i for i in ids]))}}]
 
-        EXCLUDE_QUERY = ['_', 'callback', 'token', 'api-key', 'q', 'q.df', 'q.op', 'id',
-                         'from-date', 'to-date', 'duplicateCount', 'repeat', 'sort-by',
-                         'reverse', 'group-by', 'page', 'page-size', 'limit']
+        EXCLUDE_QUERY = ['_', 'callback', 'token', 'api-key', 'q', 'q.df', 'q.op', 'id', 'from-date', 'to-date',
+                         'duplicateCount', 'repeat', 'sort-by', 'reverse', 'group-by', 'page', 'page-size', 'limit',
+                         'show-raw-data', 'show-history']
         # fields
         for field in params:
             if field in EXCLUDE_QUERY:

--- a/alerta/database/backends/postgres/utils.py
+++ b/alerta/database/backends/postgres/utils.py
@@ -105,9 +105,9 @@ class QueryBuilderImpl(QueryBuilder):
             query.append('AND (id ~* (%(regex_id)s) OR last_receive_id ~* (%(regex_id)s))')
             qvars['regex_id'] = '|'.join(['^' + i for i in ids])
 
-        EXCLUDE_QUERY = ['_', 'callback', 'token', 'api-key', 'q', 'q.df', 'id',
-                         'from-date', 'to-date', 'duplicateCount', 'repeat', 'sort-by',
-                         'reverse', 'group-by', 'page', 'page-size', 'limit']
+        EXCLUDE_QUERY = ['_', 'callback', 'token', 'api-key', 'q', 'q.df', 'id', 'from-date', 'to-date',
+                         'duplicateCount', 'repeat', 'sort-by', 'reverse', 'group-by', 'page', 'page-size', 'limit',
+                         'show-raw-data', 'show-history']
 
         # fields
         for field in params:

--- a/alerta/views/alerts.py
+++ b/alerta/views/alerts.py
@@ -296,6 +296,8 @@ def delete_alert(alert_id):
 def search_alerts():
     query_time = datetime.utcnow()
     query = qb.from_params(request.args, customers=g.customers, query_time=query_time)
+    show_raw_data = request.args.get('show-raw-data', default=False, type=lambda x: x.lower() in ['true', 't', '1', 'yes', 'y', 'on'])
+    show_history = request.args.get('show-history', default=False, type=lambda x: x.lower() in ['true', 't', '1', 'yes', 'y', 'on'])
     severity_count = Alert.get_counts_by_severity(query)
     status_count = Alert.get_counts_by_status(query)
 
@@ -303,6 +305,12 @@ def search_alerts():
     paging = Page.from_params(request.args, total)
 
     alerts = Alert.find_all(query, paging.page, paging.page_size)
+
+    for alert in alerts:
+        if not show_raw_data:
+            alert.raw_data = None
+        if not show_history:
+            alert.history = []
 
     if alerts:
         return jsonify(


### PR DESCRIPTION
Improve performance by reducing "alerts" response size. ie. only including `rawData` and alert `history` is specifically requested using `show-raw-data` and `show-history` query parameters.

Example

```
$ http ':8080/alerts?show-history=yes'
```

Fixes #1308