### PR TITLE
Refactor LDAP auth to simplify config

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -57,7 +57,7 @@ jobs:
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/alerta
         run: |
-          pytest --cov=alerta
+          pytest --cov=alerta tests/*.py
 
   test-mongodb:
     runs-on: ubuntu-latest
@@ -100,4 +100,47 @@ jobs:
         env:
           DATABASE_URL: mongodb://127.0.0.1:27017/alerta
         run: |
-          pytest --cov=alerta
+          pytest --cov=alerta tests/*.py
+
+  test-integration:
+    runs-on: ubuntu-latest
+
+    services:
+      mongodb:
+        image: mongo
+        ports:
+          - 27017:27017
+      ldap:
+        image: rroemhild/test-openldap
+        ports:
+          - 389:389
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install packages
+        run: |
+          sudo apt-get install -y \
+            build-essential \
+            python3-dev \
+            libldap2-dev \
+            libsasl2-dev
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+          architecture: 'x64'
+      - name: Install dependencies
+        id: install-deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+          pip install python-ldap
+          pip install .
+      - name: Integration Test with pytest
+        id: integration-test
+        env:
+          DATABASE_URL: mongodb://127.0.0.1:27017/alerta
+        run: |
+          pytest tests/integration

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ MYPY=$(VENV)/bin/mypy
 BLACK=$(VENV)/bin/black
 TOX=$(VENV)/bin/tox
 PYTEST=$(VENV)/bin/pytest
+DOCKER_COMPOSE=docker-compose
 PRE_COMMIT=$(VENV)/bin/pre-commit
 WHEEL=$(VENV)/bin/wheel
 TWINE=$(VENV)/bin/twine
@@ -73,9 +74,15 @@ lint: $(PYLINT) $(BLACK) $(MYPY)
 	$(BLACK) -l120 -S --check -v $(PROJECT) || true
 	$(MYPY) $(PROJECT)/
 
-## test			- Run unit tests.
-test: $(TOX) $(PYTEST)
+## test.unit		- Run unit tests.
+test: test.unit
+test.unit: $(TOX) $(PYTEST)
 	$(TOX) $(toxparams)
+
+## test.integration	- Run integration tests.
+test.integration: $(PYTEST)
+	$(DOCKER_COMPOSE) -f docker-compose.ci.yml up -d
+	$(PYTEST) tests/integration
 
 ## run			- Run application.
 run:

--- a/alerta/auth/github.py
+++ b/alerta/auth/github.py
@@ -48,7 +48,7 @@ def github():
     name = profile['name']
     username = '@' + profile['login']
     email = profile['email']
-    email_verified = True if email else False
+    email_verified = bool(email)
     picture = profile['avatar_url']
 
     login = username or email

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -100,17 +100,22 @@ ALLOWED_GITLAB_GROUPS = None
 
 # BasicAuth using LDAP
 LDAP_URL = ''  # eg. ldap://localhost:389
-LDAP_BIND_USERNAME = ''  # Optional: Only needed if defined domain in LDAP_DOMAINS_SEARCH_QUERY. eg. uid=admin,ou=users,dc=domain,dc=com
-LDAP_BIND_PASSWORD = ''  # Optional: Only needed if defined domain in LDAP_DOMAINS_SEARCH_QUERY.
-LDAP_DOMAINS = {}  # type: Dict[str, str]
-LDAP_DOMAINS_GROUP = {}  # type: Dict[str, str]
-LDAP_DOMAINS_BASEDN = {}  # type: Dict[str, str]
-LDAP_DOMAINS_USER_BASEDN = {}  # type: Dict[str, str] # If not defined, it will take BASEDN
-LDAP_DOMAINS_GROUP_BASEDN = {}  # type: Dict[str, str] # If not defined, it will take BASEDN
-LDAP_DOMAINS_SEARCH_QUERY = {}  # type: Dict[str, str]
-LDAP_ALLOW_SELF_SIGNED_CERT = False
-LDAP_DEFAULT_DOMAIN = ''
+LDAP_BASEDN = ''
 LDAP_CACERT = ''  # Path to CA certificate to verify LDAPS connection against
+LDAP_ALLOW_SELF_SIGNED_CERT = False
+LDAP_DOMAINS = {
+    # 'planetexpress.com': 'cn=%s,ou=people,dc=planetexpress,dc=com'
+}
+LDAP_BIND_USERNAME = ''  # required if using LDAP_SEARCH_QUERY eg. uid=admin,ou=users,dc=domain,dc=com
+LDAP_BIND_PASSWORD = ''  # required if using LDAP_BIND_USERNAME
+LDAP_USER_BASEDN = ''  # BASEDN for user search (default: LDAP_BASEDN)
+LDAP_USER_FILTER = ''  # eg. (cn={username})
+LDAP_USER_NAME_ATTR = 'cn'  # eg. cn or displayName
+LDAP_USER_EMAIL_ATTR = 'mail'  # eg. mail or email
+LDAP_GROUP_BASEDN = ''  # BASEDN for group search (default: LDAP_BASEDN)
+LDAP_GROUP_FILTER = ''  # eg. (&(member={userdn})(objectClass=group))
+LDAP_GROUP_NAME_ATTR = 'memberOf'  # eg. memberOf or cn
+LDAP_DEFAULT_DOMAIN = ''  # if set allows users to login with bare username
 
 # Microsoft Identity Platform (v2.0)
 AZURE_TENANT = 'common'  # "common", "organizations", "consumers" or tenant ID

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+services:
+  openldap:
+    image: rroemhild/test-openldap
+    ports:
+      - 389:389

--- a/tests/integration/test_auth_ldap.py
+++ b/tests/integration/test_auth_ldap.py
@@ -1,0 +1,123 @@
+import json
+import unittest
+
+from alerta.app import create_app
+from alerta.models.token import Jwt
+
+
+class LDAPIntegrationTestCase(unittest.TestCase):
+
+    def setUp(self):
+
+        test_config = {
+            'TESTING': True,
+            'DEBUG': True,
+            'AUTH_REQUIRED': False,
+            'ADMIN_USERS': ['professor@planetexpress.com'],
+
+            'AUTH_PROVIDER': 'ldap',
+            'ALLOWED_EMAIL_DOMAINS': ['planetexpress.com'],
+            'LDAP_URL': 'ldap://localhost:389',
+            'LDAP_BASEDN': 'dc=planetexpress,dc=com',
+
+            'LDAP_DOMAINS': {
+                # 'planetexpress.com': 'cn=%s,ou=people,dc=planetexpress,dc=com',
+            },
+
+            'LDAP_BIND_USERNAME': 'cn=admin,dc=planetexpress,dc=com',
+            'LDAP_BIND_PASSWORD': 'GoodNewsEveryone',
+
+            'LDAP_USER_BASEDN': 'ou=people,dc=planetexpress,dc=com',
+            'LDAP_USER_FILTER': '(&(uid={username})(objectClass=inetOrgPerson))',
+            'LDAP_USER_NAME_ATTR': 'cn',
+            'LDAP_USER_EMAIL_ATTR': 'mail',
+
+            'LDAP_GROUP_BASEDN': 'ou=people,dc=planetexpress,dc=com',
+            'LDAP_GROUP_FILTER': '(&(member={userdn})(objectClass=group))',
+            'LDAP_GROUP_NAME_ATTR': 'cn',  # memberOf or cn
+
+            'LDAP_DEFAULT_DOMAIN': 'planetexpress.com'
+        }
+        self.app = create_app(test_config)
+        self.client = self.app.test_client()
+
+    def test_login(self):
+
+        payload = {
+            'email': 'bender@planetexpress.com',
+            'password': 'bender'
+        }
+        response = self.client.post('/auth/login', data=json.dumps(payload), content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertIn('token', data)
+
+        with self.app.test_request_context():
+            jwt = Jwt.parse(data['token'])
+
+        self.assertEqual(jwt.issuer, 'http://localhost/')
+        self.assertEqual(jwt.name, 'Bender Bending Rodríguez')
+        self.assertEqual(jwt.preferred_username, 'bender@planetexpress.com')
+        self.assertEqual(jwt.email, 'bender@planetexpress.com')
+        self.assertEqual(jwt.provider, 'ldap')
+        self.assertEqual(jwt.orgs, [])
+        self.assertEqual(jwt.groups, ['ship_crew'])
+        self.assertEqual(jwt.roles, ['user'])
+        self.assertEqual(jwt.scopes, ['read', 'write'])
+        self.assertEqual(jwt.email_verified, True)
+        self.assertEqual(jwt.picture, None)
+        self.assertEqual(jwt.customers, [])
+
+    def test_login_with_ldap_domain(self):
+
+        payload = {
+            'username': 'planetexpress.com\\leela',
+            'password': 'leela'
+        }
+        response = self.client.post('/auth/login', data=json.dumps(payload), content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertIn('token', data)
+
+        with self.app.test_request_context():
+            jwt = Jwt.parse(data['token'])
+
+        self.assertEqual(jwt.issuer, 'http://localhost/')
+        self.assertEqual(jwt.name, 'Turanga Leela')
+        self.assertEqual(jwt.preferred_username, 'leela@planetexpress.com')
+        self.assertEqual(jwt.email, 'leela@planetexpress.com')
+        self.assertEqual(jwt.provider, 'ldap')
+        self.assertEqual(jwt.orgs, [])
+        self.assertEqual(jwt.groups, ['ship_crew'])
+        self.assertEqual(jwt.roles, ['user'])
+        self.assertEqual(jwt.scopes, ['read', 'write'])
+        self.assertEqual(jwt.email_verified, True)
+        self.assertEqual(jwt.picture, None)
+        self.assertEqual(jwt.customers, [])
+
+    def test_login_with_no_domain(self):
+
+        payload = {
+            'username': 'professor',
+            'password': 'professor'
+        }
+        response = self.client.post('/auth/login', data=json.dumps(payload), content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertIn('token', data)
+
+        with self.app.test_request_context():
+            jwt = Jwt.parse(data['token'])
+
+        self.assertEqual(jwt.issuer, 'http://localhost/')
+        self.assertEqual(jwt.name, 'Hubert J. Farnsworth')
+        self.assertEqual(jwt.preferred_username, 'professor@planetexpress.com')
+        self.assertEqual(jwt.email, 'professor@planetexpress.com')
+        self.assertEqual(jwt.provider, 'ldap')
+        self.assertEqual(jwt.orgs, [])
+        self.assertEqual(jwt.groups, ['admin_staff'])
+        self.assertEqual(jwt.roles, ['admin'])
+        self.assertEqual(jwt.scopes, ['admin', 'read', 'write'])
+        self.assertEqual(jwt.email_verified, True)
+        self.assertEqual(jwt.picture, None)
+        self.assertEqual(jwt.customers, [])


### PR DESCRIPTION
All supported LDAP configuration settings...
```
# BasicAuth using LDAP
LDAP_URL = ''  # eg. ldap://localhost:389
LDAP_BASEDN = ''
LDAP_CACERT = ''  # Path to CA certificate to verify LDAPS connection against
LDAP_ALLOW_SELF_SIGNED_CERT = False
LDAP_DOMAINS = {
    # 'planetexpress.com': 'cn=%s,ou=people,dc=planetexpress,dc=com',
    # 'sicredi.com': 'uid={0},cn={0:.1},cn=users,dc=sicredi,dc=com,dc=br'
}
LDAP_BIND_USERNAME = ''  # required if using LDAP_SEARCH_QUERY eg. uid=admin,ou=users,dc=domain,dc=com
LDAP_BIND_PASSWORD = ''  # required if using LDAP_BIND_USERNAME
LDAP_USER_BASEDN = ''  # BASEDN for user search (default: LDAP_BASEDN)
LDAP_USER_FILTER = ''  # eg. (cn={username})
LDAP_USER_NAME_ATTR = 'cn'  # eg. cn or displayName
LDAP_USER_EMAIL_ATTR = 'mail'  # eg. mail or email
LDAP_GROUP_BASEDN = ''  # BASEDN for group search (default: LDAP_BASEDN)
LDAP_GROUP_FILTER = ''  # eg. (&(member={userdn})(objectClass=group))
LDAP_GROUP_NAME_ATTR = 'memberOf'  # eg. memberOf or cn
LDAP_DEFAULT_DOMAIN = ''  # if set allows users to login with bare username
ALLOWED_EMAIL_DOMAINS = []
```

Example...
```
AUTH_PROVIDER='ldap'
LDAP_URL='ldap://localhost:389'
LDAP_BASEDN='ou=people,dc=planetexpress,dc=com'
LDAP_BIND_USERNAME='cn=admin,dc=planetexpress,dc=com'
LDAP_BIND_PASSWORD='GoodNewsEveryone'
LDAP_USER_FILTER='(&(uid={username})(objectClass=inetOrgPerson))'
LDAP_USER_NAME_ATTR='cn'
LDAP_USER_EMAIL_ATTR='mail',
LDAP_GROUP_FILTER='(&(member={userdn})(objectClass=group))'
LDAP_GROUP_NAME_ATTR='cn'
ALLOWED_EMAIL_DOMAINS=['planetexpress.com']
````

Improves #1206 Fixes #951

/cc @frasy @KlavsKlavsen @Anderen2 @PMDubuc @carlospeon @raffis @olivluca