### PR TITLE
Take advantage of simplified SQL in Postgres 9.6

### DIFF
--- a/alerta/sql/schema.sql
+++ b/alerta/sql/schema.sql
@@ -59,12 +59,8 @@ CREATE TABLE IF NOT EXISTS alerts (
     history history[]
 );
 
-DO $$
-BEGIN
-    ALTER TABLE alerts ADD COLUMN update_time timestamp without time zone;
-EXCEPTION
-    WHEN duplicate_column THEN RAISE NOTICE 'column "update_time" already exists in alerts.';
-END$$;
+ALTER TABLE alerts ADD COLUMN IF NOT EXISTS update_time timestamp without time zone;
+
 
 CREATE TABLE IF NOT EXISTS notes (
     id text PRIMARY KEY,
@@ -94,32 +90,10 @@ CREATE TABLE IF NOT EXISTS blackouts (
     duration integer
 );
 
--- Support for "IF NOT EXISTS" added to "ADD COLUMN" in Postgres 9.6
--- ALTER TABLE blackouts
--- ADD COLUMN IF NOT EXISTS "user" text,
--- ADD COLUMN IF NOT EXISTS create_time timestamp without time zone,
--- ADD COLUMN IF NOT EXISTS text text;
-
-DO $$
-BEGIN
-    ALTER TABLE blackouts ADD COLUMN "user" text;
-EXCEPTION
-    WHEN duplicate_column THEN RAISE NOTICE 'column "user" already exists in blackouts.';
-END$$;
-
-DO $$
-BEGIN
-    ALTER TABLE blackouts ADD COLUMN create_time timestamp without time zone;
-EXCEPTION
-    WHEN duplicate_column THEN RAISE NOTICE 'column "create_time" already exists in blackouts.';
-END$$;
-
-DO $$
-BEGIN
-    ALTER TABLE blackouts ADD COLUMN text text;
-EXCEPTION
-    WHEN duplicate_column THEN RAISE NOTICE 'column "text" already exists in blackouts.';
-END$$;
+ALTER TABLE blackouts
+ADD COLUMN IF NOT EXISTS "user" text,
+ADD COLUMN IF NOT EXISTS create_time timestamp without time zone,
+ADD COLUMN IF NOT EXISTS text text;
 
 
 CREATE TABLE IF NOT EXISTS customers (
@@ -142,12 +116,7 @@ CREATE TABLE IF NOT EXISTS heartbeats (
     customer text
 );
 
-DO $$
-BEGIN
-    ALTER TABLE heartbeats ADD COLUMN attributes jsonb;
-EXCEPTION
-    WHEN duplicate_column THEN RAISE NOTICE 'column "attributes" already exists in heartbeats.';
-END$$;
+ALTER TABLE heartbeats ADD COLUMN IF NOT EXISTS attributes jsonb;
 
 
 CREATE TABLE IF NOT EXISTS keys (


### PR DESCRIPTION
Postgres 9.5 is EOL in 4 months. We can finally take advantage of Postgres 9.6 syntax. See https://www.postgresql.org/docs/9.6/sql-altertable.html

Fixes #1184