### PR TITLE
Add LDAP config for allowed groups

### DIFF
--- a/alerta/auth/basic_ldap.py
+++ b/alerta/auth/basic_ldap.py
@@ -1,7 +1,7 @@
 import ldap  # pylint: disable=import-error
 from flask import current_app, jsonify, request
 
-from alerta.auth.utils import create_token, get_customers
+from alerta.auth.utils import create_token, get_customers, not_authorized
 from alerta.exceptions import ApiError
 from alerta.models.permission import Permission
 from alerta.models.user import User
@@ -143,6 +143,8 @@ def login():
     # Check user is active
     if user.status != 'active':
         raise ApiError('User {} not active'.format(login), 403)
+    if not_authorized('ALLOWED_LDAP_GROUPS', groups):
+        raise ApiError('User {} is not authorized'.format(login), 403)
     user.update_last_login()
 
     scopes = Permission.lookup(login=login, roles=user.roles + groups)

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -96,7 +96,7 @@ ALLOWED_GITHUB_ORGS = ['*']
 
 # GitLab OAuth2
 GITLAB_URL = 'https://gitlab.com'
-ALLOWED_GITLAB_GROUPS = None
+ALLOWED_GITLAB_GROUPS = ['*']
 
 # BasicAuth using LDAP
 LDAP_URL = ''  # eg. ldap://localhost:389
@@ -116,6 +116,7 @@ LDAP_GROUP_BASEDN = ''  # BASEDN for group search (default: LDAP_BASEDN)
 LDAP_GROUP_FILTER = ''  # eg. (&(member={userdn})(objectClass=group))
 LDAP_GROUP_NAME_ATTR = 'memberOf'  # eg. memberOf or cn
 LDAP_DEFAULT_DOMAIN = ''  # if set allows users to login with bare username
+ALLOWED_LDAP_GROUPS = ['*']
 
 # Microsoft Identity Platform (v2.0)
 AZURE_TENANT = 'common'  # "common", "organizations", "consumers" or tenant ID
@@ -123,7 +124,7 @@ AZURE_TENANT = 'common'  # "common", "organizations", "consumers" or tenant ID
 # Keycloak
 KEYCLOAK_URL = None
 KEYCLOAK_REALM = None
-ALLOWED_KEYCLOAK_ROLES = None
+ALLOWED_KEYCLOAK_ROLES = ['*']
 
 # OpenID Connect
 OIDC_ISSUER_URL = None

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -114,7 +114,7 @@ LDAP_USER_NAME_ATTR = 'cn'  # eg. cn or displayName
 LDAP_USER_EMAIL_ATTR = 'mail'  # eg. mail or email
 LDAP_GROUP_BASEDN = ''  # BASEDN for group search (default: LDAP_BASEDN)
 LDAP_GROUP_FILTER = ''  # eg. (&(member={userdn})(objectClass=group))
-LDAP_GROUP_NAME_ATTR = 'memberOf'  # eg. memberOf or cn
+LDAP_GROUP_NAME_ATTR = 'dn'  # eg. dn, memberOf, or cn
 LDAP_DEFAULT_DOMAIN = ''  # if set allows users to login with bare username
 ALLOWED_LDAP_GROUPS = ['*']
 

--- a/tests/integration/test_auth_ldap.py
+++ b/tests/integration/test_auth_ldap.py
@@ -33,11 +33,31 @@ class LDAPIntegrationTestCase(unittest.TestCase):
             'LDAP_USER_EMAIL_ATTR': 'mail',
 
             'LDAP_GROUP_BASEDN': 'ou=people,dc=planetexpress,dc=com',
-            'LDAP_GROUP_FILTER': '(&(member={userdn})(objectClass=group))',
-            'LDAP_GROUP_NAME_ATTR': 'cn',  # memberOf or cn
+
+            # Scenario 1. default usage using group DN
+            # 'LDAP_GROUP_FILTER': '(&(member={userdn})(objectClass=group))',
+            # 'ALLOWED_LDAP_GROUPS': [
+            #     'cn=admin_staff,ou=people,dc=planetexpress,dc=com',
+            #     'cn=ship_crew,ou=people,dc=planetexpress,dc=com'
+            # ],
+
+            # Scenario 2. group cn is (short) group name
+            # 'LDAP_GROUP_FILTER': '(&(member={userdn})(objectClass=group))',
+            # 'LDAP_GROUP_NAME_ATTR': 'cn',
+            # 'ALLOWED_LDAP_GROUPS': [
+            #     'admin_staff',
+            #     'ship_crew'
+            # ],
+
+            # Scenario 3. memberOf dn is used as group name
+            'LDAP_GROUP_FILTER': '(&(uid={username})(objectClass=inetOrgPerson))',
+            'LDAP_GROUP_NAME_ATTR': 'memberOf',
+            'ALLOWED_LDAP_GROUPS': [
+                'cn=admin_staff,ou=people,dc=planetexpress,dc=com',
+                'cn=ship_crew,ou=people,dc=planetexpress,dc=com'
+            ],
 
             'LDAP_DEFAULT_DOMAIN': 'planetexpress.com',
-            'ALLOWED_LDAP_GROUPS': ['admin_staff', 'ship_crew']
         }
         self.app = create_app(test_config)
         self.client = self.app.test_client()
@@ -62,7 +82,7 @@ class LDAPIntegrationTestCase(unittest.TestCase):
         self.assertEqual(jwt.email, 'bender@planetexpress.com')
         self.assertEqual(jwt.provider, 'ldap')
         self.assertEqual(jwt.orgs, [])
-        self.assertEqual(jwt.groups, ['ship_crew'])
+        self.assertEqual(jwt.groups, ['cn=ship_crew,ou=people,dc=planetexpress,dc=com'])
         self.assertEqual(jwt.roles, ['user'])
         self.assertEqual(jwt.scopes, ['read', 'write'])
         self.assertEqual(jwt.email_verified, True)
@@ -89,7 +109,7 @@ class LDAPIntegrationTestCase(unittest.TestCase):
         self.assertEqual(jwt.email, 'leela@planetexpress.com')
         self.assertEqual(jwt.provider, 'ldap')
         self.assertEqual(jwt.orgs, [])
-        self.assertEqual(jwt.groups, ['ship_crew'])
+        self.assertEqual(jwt.groups, ['cn=ship_crew,ou=people,dc=planetexpress,dc=com'])
         self.assertEqual(jwt.roles, ['user'])
         self.assertEqual(jwt.scopes, ['read', 'write'])
         self.assertEqual(jwt.email_verified, True)
@@ -116,7 +136,7 @@ class LDAPIntegrationTestCase(unittest.TestCase):
         self.assertEqual(jwt.email, 'professor@planetexpress.com')
         self.assertEqual(jwt.provider, 'ldap')
         self.assertEqual(jwt.orgs, [])
-        self.assertEqual(jwt.groups, ['admin_staff'])
+        self.assertEqual(jwt.groups, ['cn=admin_staff,ou=people,dc=planetexpress,dc=com'])
         self.assertEqual(jwt.roles, ['admin'])
         self.assertEqual(jwt.scopes, ['admin', 'read', 'write'])
         self.assertEqual(jwt.email_verified, True)

--- a/tests/integration/test_auth_ldap.py
+++ b/tests/integration/test_auth_ldap.py
@@ -12,7 +12,7 @@ class LDAPIntegrationTestCase(unittest.TestCase):
         test_config = {
             'TESTING': True,
             'DEBUG': True,
-            'AUTH_REQUIRED': False,
+            'AUTH_REQUIRED': True,
             'ADMIN_USERS': ['professor@planetexpress.com'],
 
             'AUTH_PROVIDER': 'ldap',
@@ -36,7 +36,8 @@ class LDAPIntegrationTestCase(unittest.TestCase):
             'LDAP_GROUP_FILTER': '(&(member={userdn})(objectClass=group))',
             'LDAP_GROUP_NAME_ATTR': 'cn',  # memberOf or cn
 
-            'LDAP_DEFAULT_DOMAIN': 'planetexpress.com'
+            'LDAP_DEFAULT_DOMAIN': 'planetexpress.com',
+            'ALLOWED_LDAP_GROUPS': ['admin_staff', 'ship_crew']
         }
         self.app = create_app(test_config)
         self.client = self.app.test_client()
@@ -121,3 +122,12 @@ class LDAPIntegrationTestCase(unittest.TestCase):
         self.assertEqual(jwt.email_verified, True)
         self.assertEqual(jwt.picture, None)
         self.assertEqual(jwt.customers, [])
+
+    def test_login_invalid_group(self):
+
+        payload = {
+            'username': 'zoidberg',
+            'password': 'zoidberg'
+        }
+        response = self.client.post('/auth/login', data=json.dumps(payload), content_type='application/json')
+        self.assertEqual(response.status_code, 403)


### PR DESCRIPTION
Fixes #1325 

References
https://www.vaultproject.io/docs/auth/ldap#group-membership-resolution
https://github.com/rroemhild/docker-test-openldap

```
$ ldapsearch -H ldap://localhost:389 \
  -v \
  -D cn=admin,dc=planetexpress,dc=com \
  -w GoodNewsEveryone \
  -b "ou=people,dc=planetexpress,dc=com" \
  -s sub \
  "(&(uid=professor)(objectClass=inetOrgPerson))" \
  "memberOf"
ldap_initialize( ldap://localhost:389/??base )
filter: (&(uid=professor)(objectClass=inetOrgPerson))
requesting: memberOf
# extended LDIF
#
# LDAPv3
# base <ou=people,dc=planetexpress,dc=com> with scope subtree
# filter: (&(uid=professor)(objectClass=inetOrgPerson))
# requesting: memberOf
#

# Hubert J. Farnsworth, people, planetexpress.com
dn: cn=Hubert J. Farnsworth,ou=people,dc=planetexpress,dc=com
memberOf: cn=admin_staff,ou=people,dc=planetexpress,dc=com

# search result
search: 2
result: 0 Success

# numResponses: 2
# numEntries: 1

$ ldapsearch -H ldap://localhost:389 \
  -v \
  -D cn=admin,dc=planetexpress,dc=com \
  -w GoodNewsEveryone \
  -b "ou=people,dc=planetexpress,dc=com" \
  -s sub \
  "(&(member=cn=Turanga Leela,ou=people,dc=planetexpress,dc=com)(objectClass=group))" \
  cn
ldap_initialize( ldap://localhost:389/??base )
filter: (&(member=cn=Turanga Leela,ou=people,dc=planetexpress,dc=com)(objectClass=group))
requesting: cn
# extended LDIF
#
# LDAPv3
# base <ou=people,dc=planetexpress,dc=com> with scope subtree
# filter: (&(member=cn=Turanga Leela,ou=people,dc=planetexpress,dc=com)(objectClass=group))
# requesting: cn
#

# ship_crew, people, planetexpress.com
dn: cn=ship_crew,ou=people,dc=planetexpress,dc=com
cn: ship_crew

# search result
search: 2
result: 0 Success

# numResponses: 2
# numEntries: 1
```
