### PR TITLE
Do not allow LDAP login with empty password

### DIFF
--- a/alerta/auth/basic_ldap.py
+++ b/alerta/auth/basic_ldap.py
@@ -27,6 +27,9 @@ def login():
     except KeyError:
         raise ApiError("must supply 'username' and 'password'", 401)
 
+    if not password:
+        raise ApiError('password not allowed to be empty', 401)
+
     try:
         if '\\' in login:
             domain, username = login.split('\\')


### PR DESCRIPTION
Backport security fix for Release 7.5 branch. Fixes #1277 