### PR TITLE
Add "delete:alerts" scope for deleting alerts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ test.unit: $(TOX) $(PYTEST)
 ## test.integration	- Run integration tests.
 test.integration: $(PYTEST)
 	$(DOCKER_COMPOSE) -f docker-compose.ci.yml up -d
-	$(PYTEST) tests/integration
+	$(PYTEST) tests/integration $(toxparams)
 
 ## run			- Run application.
 run:

--- a/alerta/models/enums.py
+++ b/alerta/models/enums.py
@@ -8,6 +8,7 @@ class Scope(str, Enum):
     admin = 'admin'
     read_alerts = 'read:alerts'
     write_alerts = 'write:alerts'
+    delete_alerts = 'delete:alerts'
     admin_alerts = 'admin:alerts'
     read_blackouts = 'read:blackouts'
     write_blackouts = 'write:blackouts'
@@ -47,7 +48,7 @@ class Scope(str, Enum):
     def from_str(action: str, resource: str = None):
         """Return a scope based on the supplied action and resource.
 
-        :param action: the scope action eg. read, write or admin
+        :param action: the scope action eg. read, write, delete or admin
         :param resource: the specific resource of the scope, if any eg. alerts,
             blackouts, heartbeats, users, perms, customers, keys, webhooks,
             oembed, management or userinfo or None

--- a/alerta/models/permission.py
+++ b/alerta/models/permission.py
@@ -1,6 +1,8 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 from uuid import uuid4
 
+from flask import current_app
+
 from alerta.app import db
 from alerta.database.base import Query
 from alerta.models.enums import Scope
@@ -96,6 +98,11 @@ class Permission:
             return cls.is_in_scope(want_scope.replace('read', 'write'), have_scopes)
         elif want_scope.startswith('write'):
             return cls.is_in_scope(want_scope.replace('write', 'admin'), have_scopes)
+        elif want_scope.startswith('delete'):
+            if want_scope in current_app.config['DELETE_SCOPES']:
+                return cls.is_in_scope(want_scope.replace('delete', 'admin'), have_scopes)
+            else:
+                return cls.is_in_scope(want_scope.replace('delete', 'write'), have_scopes)
         else:
             return False
 

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -68,6 +68,7 @@ USER_DEFAULT_SCOPES = ['read', 'write']  # Note: 'write' scope implicitly includ
 DEFAULT_GUEST_ROLE = 'guest'
 GUEST_ROLES = [DEFAULT_GUEST_ROLE]
 GUEST_DEFAULT_SCOPES = ['read:alerts']
+DELETE_SCOPES = []  # Set to "delete:alerts" to prevent users with "write:alerts" scope being able to delete alerts
 CUSTOMER_VIEWS = False
 
 BASIC_AUTH_REALM = 'Alerta'

--- a/alerta/views/alerts.py
+++ b/alerta/views/alerts.py
@@ -259,7 +259,7 @@ def update_attributes(alert_id):
 # delete
 @api.route('/alert/<alert_id>', methods=['OPTIONS', 'DELETE'])
 @cross_origin()
-@permission(Scope.write_alerts)
+@permission(Scope.delete_alerts)
 @timer(delete_timer)
 @jsonp
 def delete_alert(alert_id):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37}-{mongodb,postgres}
+envlist = py{37,38,39}-{mongodb,postgres}
 skip_missing_interpreters=true
 
 [testenv]


### PR DESCRIPTION
To prevent users with "write" permission from being able to delete alerts, set the following server configuration option to add the additional scope of "delete:alerts" which would then be required for all users who want to delete alerts, except for those with "admin" permissions.

```
DELETE_SCOPES = ['delete:alerts']
```

Fixes #1371 