### PR TITLE
Link OpenID user accounts by email

### DIFF
--- a/alerta/models/token.py
+++ b/alerta/models/token.py
@@ -37,6 +37,7 @@ class Jwt:
         self.email_verified = kwargs.get('email_verified')
         self.picture = kwargs.get('picture')
         self.customers = kwargs.get('customers')
+        self.oid = kwargs.get('oid')
 
     @classmethod
     def parse(cls, token: str, key: str = None, verify: bool = True, algorithm: str = 'HS256') -> 'Jwt':
@@ -70,7 +71,8 @@ class Jwt:
             scopes=json.get('scope', '').split(' '),  # eg. scope='read write' => scopes=['read', 'write']
             email_verified=json.get('email_verified', None),
             picture=json.get('picture', None),
-            customers=[json['customer']] if 'customer' in json else json.get('customers', list())
+            customers=[json['customer']] if 'customer' in json else json.get('customers', list()),
+            oid=json.get('oid')
         )
 
     @property
@@ -108,6 +110,8 @@ class Jwt:
             data['picture'] = self.picture
         if current_app.config['CUSTOMER_VIEWS']:
             data['customers'] = self.customers
+        if self.oid:
+            data['oid'] = self.oid
         return data
 
     @property

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -135,6 +135,7 @@ OIDC_VERIFY_TOKEN = False
 OIDC_ROLE_CLAIM = OIDC_CUSTOM_CLAIM = 'roles'  # JWT claim name whose value is used in role mapping
 OIDC_GROUP_CLAIM = 'groups'  # JWT claim name whose value is used in customer mapping
 ALLOWED_OIDC_ROLES = ALLOWED_GITLAB_GROUPS or ALLOWED_KEYCLOAK_ROLES or ['*']
+OIDC_LINK_USER_EMAIL = True  # if using federated IdP link user accounts by verified email addresses
 
 # SAML 2.0
 SAML2_ENTITY_ID = None


### PR DESCRIPTION
Lets users of federated OpenID connect Identity Providers login with any linked account. User accounts will be linked by email addresses if the email address has been verified by the Auth Provider. The first account to be used by a user becomes the "primary" account and the user id will not change.

The "subject" claim (ie. user id) of the user will be added to JWT auth tokens as the "oid" claim if a user logs in using a different auth provider. It will require some small work at the web UI to support the new JWT claim "oid" (original user id or object id) so that the user profile endpoints work.

Note: may need to reprompt users for permissions (like email) if initially declined. See https://auth0.com/docs/connections/social/reprompt-permissions

Can be disabled by setting `OIDC_LINK_USER_EMAIL` to `False`.

*References*
https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens (see "oid" claim)
https://auth0.com/docs/users/verified-email-usage#verified-emails-and-account-linking

Fixes #1336 
