### PR TITLE
Add take_note plugin method

### DIFF
--- a/alerta/plugins/__init__.py
+++ b/alerta/plugins/__init__.py
@@ -38,6 +38,10 @@ class PluginBase(metaclass=abc.ABCMeta):
         """Trigger integrations based on external actions. (optional)"""
         raise NotImplementedError
 
+    def take_note(self, alert: 'Alert', text: str, **kwargs) -> Any:
+        """Trigger integrations based on notes. (optional)"""
+        raise NotImplementedError
+
     def delete(self, alert: 'Alert', **kwargs) -> bool:
         """Trigger integrations when an alert is deleted. (optional)"""
         raise NotImplementedError

--- a/alerta/plugins/__init__.py
+++ b/alerta/plugins/__init__.py
@@ -38,7 +38,7 @@ class PluginBase(metaclass=abc.ABCMeta):
         """Trigger integrations based on external actions. (optional)"""
         raise NotImplementedError
 
-    def take_note(self, alert: 'Alert', text: str, **kwargs) -> Any:
+    def take_note(self, alert: 'Alert', text: Optional[str], **kwargs) -> Any:
         """Trigger integrations based on notes. (optional)"""
         raise NotImplementedError
 

--- a/alerta/views/alerts.py
+++ b/alerta/views/alerts.py
@@ -650,14 +650,12 @@ def update_note(alert_id, note_id):
 
     update = request.json
     update['user'] = g.login
-    if update.get('text', ''):
-        alert, note_text = process_note(alert, update['text'])
-        update['text'] = note_text
 
     write_audit_trail.send(current_app._get_current_object(), event='alert-note-updated', message='', user=g.login,
                            customers=g.customers, scopes=g.scopes, resource_id=note.id, type='note',
                            request=request)
 
+    _, update['text'] = process_note(alert, update.get('text'))
     updated = note.update(**update)
     if updated:
         return jsonify(status='ok', note=updated.serialize)


### PR DESCRIPTION
Closes #1382 

This PR:
* adds the `take_note()` method for plugins
* processes notes when created or updated with a text
* adds minimal tests cases: trigger plugin on create, trigger plugin on update, check attributes changes are properly saved

I mimicked the `take_action` support for the plugin returning either `Alert` or `Tupple(Alert, something)`, this looks like backward compatibility for legacy plugins, I'm not sure if keeping it makes sense.