### PR TITLE
removing None tupples from Active directory partitions on LDAP respon…

### DIFF
--- a/alerta/auth/basic_ldap.py
+++ b/alerta/auth/basic_ldap.py
@@ -1,5 +1,4 @@
 import ldap  # pylint: disable=import-error
-import logging
 from flask import current_app, jsonify, request
 
 from alerta.auth.utils import create_token, get_customers, not_authorized

--- a/tests/integration/test_auth_ldap.py
+++ b/tests/integration/test_auth_ldap.py
@@ -34,6 +34,7 @@ class LDAPIntegrationTestCase(unittest.TestCase):
 
             'LDAP_GROUP_BASEDN': 'ou=people,dc=planetexpress,dc=com',
 
+            'LDAP_QUERY_TIMEOUT_SECONDS': 3,
             # Scenario 1. default usage using group DN
             # 'LDAP_GROUP_FILTER': '(&(member={userdn})(objectClass=group))',
             # 'ALLOWED_LDAP_GROUPS': [


### PR DESCRIPTION
code to fix https://github.com/alerta/alerta/issues/1391.

(1) Handles replies from all Active Directory Partitions, removing None tupples before failing.
(2) adds timeout to Ldap search if parameter LDAP_QUERY_TIMEOUT_SECONDS is added to configuration file.
