### PR TITLE
Support custom LDAP config options

### DIFF
--- a/alerta/auth/basic_ldap.py
+++ b/alerta/auth/basic_ldap.py
@@ -45,9 +45,13 @@ def login():
     if current_app.config['LDAP_ALLOW_SELF_SIGNED_CERT']:
         ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_ALLOW)
 
-    # Set LDAP Timeout:
-    if current_app.config['LDAP_QUERY_TIMEOUT_SECONDS']:
-        ldap.set_option(ldap.OPT_NETWORK_TIMEOUT, current_app.config['LDAP_QUERY_TIMEOUT_SECONDS'])
+    # Set LDAP Timeout
+    if current_app.config['LDAP_TIMEOUT']:
+        ldap.set_option(ldap.OPT_NETWORK_TIMEOUT, current_app.config['LDAP_TIMEOUT'])
+
+    # Set custom config options
+    for k, v in current_app.config['LDAP_CONFIG'].items():
+        ldap.set_option(getattr(ldap, k), v)
 
     # Initialise ldap connection
     try:

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -101,6 +101,7 @@ ALLOWED_GITLAB_GROUPS = ['*']
 
 # BasicAuth using LDAP
 LDAP_URL = ''  # eg. ldap://localhost:389
+LDAP_TIMEOUT = -1  # seconds (-1=infinity)
 LDAP_BASEDN = ''
 LDAP_CACERT = ''  # Path to CA certificate to verify LDAPS connection against
 LDAP_ALLOW_SELF_SIGNED_CERT = False
@@ -117,6 +118,7 @@ LDAP_GROUP_BASEDN = ''  # BASEDN for group search (default: LDAP_BASEDN)
 LDAP_GROUP_FILTER = ''  # eg. (&(member={userdn})(objectClass=group))
 LDAP_GROUP_NAME_ATTR = 'dn'  # eg. dn, memberOf, or cn
 LDAP_DEFAULT_DOMAIN = ''  # if set allows users to login with bare username
+LDAP_CONFIG = {}  # type: Dict[str, Any]
 ALLOWED_LDAP_GROUPS = ['*']
 
 # Microsoft Identity Platform (v2.0)

--- a/tests/integration/test_auth_ldap.py
+++ b/tests/integration/test_auth_ldap.py
@@ -18,6 +18,7 @@ class LDAPIntegrationTestCase(unittest.TestCase):
             'AUTH_PROVIDER': 'ldap',
             'ALLOWED_EMAIL_DOMAINS': ['planetexpress.com'],
             'LDAP_URL': 'ldap://localhost:389',
+            'LDAP_TIMEOUT': 10,
             'LDAP_BASEDN': 'dc=planetexpress,dc=com',
 
             'LDAP_DOMAINS': {
@@ -34,7 +35,11 @@ class LDAPIntegrationTestCase(unittest.TestCase):
 
             'LDAP_GROUP_BASEDN': 'ou=people,dc=planetexpress,dc=com',
 
-            'LDAP_QUERY_TIMEOUT_SECONDS': 3,
+            'LDAP_CONFIG': {
+                'OPT_REFERRALS': 0,
+                'OPT_PROTOCOL_VERSION': 3,
+                'OPT_DEBUG_LEVEL': -1
+            },
             # Scenario 1. default usage using group DN
             # 'LDAP_GROUP_FILTER': '(&(member={userdn})(objectClass=group))',
             # 'ALLOWED_LDAP_GROUPS': [


### PR DESCRIPTION
Should help with trying to troubleshoot LDAP issues, like #1208 and #1373.

Example
```
            'LDAP_CONFIG': {
                'OPT_REFERRALS': 0,
                'OPT_PROTOCOL_VERSION': 3,
                'OPT_DEBUG_LEVEL': -1
            },
```