### PR TITLE
Fix query parser exact match for nested queries

### DIFF
--- a/alerta/database/backends/mongodb/queryparser.py
+++ b/alerta/database/backends/mongodb/queryparser.py
@@ -66,18 +66,19 @@ class SearchTerm:
                 return '{{"attributes.{}": {{"$exists": true}}}}'.format(self.tokens.singleterm)
             else:
                 if self.tokens.field[0] == '__default_field__':
-                    return '{{"{}": {{"{}": "{}"}}}}'.format('__default_field__', '__default_operator__', self.tokens.singleterm)
+                    return '{{"{}": {{"{}": "{}", "$options": "i"}}}}'.format('__default_field__', '__default_operator__', self.tokens.singleterm)
                 else:
-                    return '{{"{}": {{"$regex": "{}"}}}}'.format(tokens_fieldname, self.tokens.singleterm)
+                    return '{{"{}": {{"$regex": "{}", "$options": "i"}}}}'.format(tokens_fieldname, self.tokens.singleterm)
         if 'phrase' in self.tokens:
-            if self.tokens.field[0] == '__default_field__':
-                return '{{"{}": {{"{}": "{}"}}}}'.format('__default_field__', '__default_operator__', self.tokens.phrase)
+            tokens_field0 = self.tokens.field[0].replace('_.', 'attributes.')
+            if tokens_field0 == '__default_field__':
+                return '{{"{}": {{"{}": "{}", "$options": "i"}}}}'.format('__default_field__', '__default_operator__', self.tokens.phrase)
             else:
-                return '{{"{}": {{"$regex": "{}"}}}}'.format(self.tokens.field[0], self.tokens.phrase)
+                return '{{"{}": {{"$regex": "\\\\b{}\\\\b", "$options": "i"}}}}'.format(tokens_field0, self.tokens.phrase)
         if 'wildcard' in self.tokens:
-            return '{{"{}": {{"$regex": "\\\\b{}\\\\b"}}}}'.format(self.tokens.field[0], self.tokens.wildcard)
+            return '{{"{}": {{"$regex": "\\\\b{}\\\\b", "$options": "i"}}}}'.format(self.tokens.field[0], self.tokens.wildcard)
         if 'regex' in self.tokens:
-            return '{{"{}": {{"$regex": "{}"}}}}'.format(self.tokens.field[0], self.tokens.regex)
+            return '{{"{}": {{"$regex": "{}", "$options": "i"}}}}'.format(self.tokens.field[0], self.tokens.regex)
 
         def range_term(field, operator, range):
             if field in ['duplicateCount', 'timeout']:

--- a/alerta/database/backends/postgres/queryparser.py
+++ b/alerta/database/backends/postgres/queryparser.py
@@ -69,6 +69,9 @@ class SearchTerm:
                 return '"{}" ~* \'\\y{}\\y\''.format('__default_field__', self.tokens.phrase)
             elif self.tokens.field[0] in ['correlate', 'service', 'tags']:
                 return '\'{}\'=ANY("{}")'.format(self.tokens.term, self.tokens.field[0])
+            elif self.tokens.attr:
+                tokens_attr = self.tokens.attr.replace('_', 'attributes')
+                return '"{}"::jsonb ->>\'{}\' ~* \'\\y{}\\y\''.format(tokens_attr, self.tokens.fieldname, self.tokens.phrase)
             else:
                 return '"{}" ~* \'\\y{}\\y\''.format(self.tokens.field[0], self.tokens.phrase)
         if 'wildcard' in self.tokens:


### PR DESCRIPTION
For example, when searching nested fields, to match a custom attribute "partition" with "7" and only "7", not "27", "79" or "278" etc. surround match with double quotes...

```
http://api.local.alerta.io:8080/alerts?q=_.partition:"7"
```

Fixes #1286 

