### PR TITLE
fix: set alert heartbeat timeout from alert timeout

### DIFF
--- a/alerta/plugins/heartbeat.py
+++ b/alerta/plugins/heartbeat.py
@@ -19,11 +19,6 @@ class HeartbeatReceiver(PluginBase):
         HEARTBEAT_EVENTS = self.get_config('HEARTBEAT_EVENTS', default=['Heartbeat'], type=list, **kwargs)
 
         if alert.event in HEARTBEAT_EVENTS:
-            if 'timeout' in request.json:
-                timeout = alert.timeout
-            else:
-                timeout = current_app.config['HEARTBEAT_TIMEOUT']
-
             hb = Heartbeat(
                 origin=alert.origin,
                 tags=alert.tags,
@@ -33,7 +28,7 @@ class HeartbeatReceiver(PluginBase):
                     'service': alert.service,
                     'group': alert.group
                 },
-                timeout=timeout,
+                timeout=alert.timeout,
                 customer=alert.customer
             )
             r = hb.create()

--- a/alerta/webhooks/prometheus.py
+++ b/alerta/webhooks/prometheus.py
@@ -49,12 +49,13 @@ def parse_prometheus(alert: JSON, external_url: str) -> Alert:
     service = labels.pop('service', '').split(',')
     group = labels.pop('group', None) or labels.pop('job', 'Prometheus')
     origin = 'prometheus/' + labels.pop('monitor', '-')
-    tags = ['{}={}'.format(k, v) for k, v in labels.items()]  # any labels left over are used for tags
 
     try:
         timeout = int(labels.pop('timeout', 0)) or None
     except ValueError:
         timeout = None
+
+    tags = ['{}={}'.format(k, v) for k, v in labels.items()]  # any labels left over are used for tags
 
     # annotations
     value = annotations.pop('value', None)

--- a/tests/test_heartbeats.py
+++ b/tests/test_heartbeats.py
@@ -196,7 +196,8 @@ class HeartbeatsTestCase(unittest.TestCase):
                 "monitor": "codelab",
                 "region": "EU",
                 "service": "Monitoring",
-                "severity": "warning"
+                "severity": "warning",
+                "timeout": "8"
               },
               "annotations": {},
               "startsAt": "2020-07-05T18:51:22.012771244Z",
@@ -244,4 +245,4 @@ class HeartbeatsTestCase(unittest.TestCase):
                 group='Healthchecks'
             )
         )
-        self.assertEqual(data['heartbeats'][0]['timeout'], 4)
+        self.assertEqual(data['heartbeats'][0]['timeout'], 8)


### PR DESCRIPTION
Heartbeats generated from alerts should use the
timeout value from the alert to set the heartbeat
timeout.

Closes #1401