### PR TITLE
feat(plugin): add timeout policy plugin to enforce ack and shelve timeouts

### DIFF
--- a/alerta/plugins/timeout.py
+++ b/alerta/plugins/timeout.py
@@ -1,0 +1,54 @@
+import logging
+from typing import TYPE_CHECKING, Any, Optional
+
+from alerta.models.enums import ChangeType
+from alerta.plugins import PluginBase
+
+if TYPE_CHECKING:
+    from alerta.models.alert import Alert  # noqa
+
+LOG = logging.getLogger('alerta.plugins')
+
+
+class TimeoutPolicy(PluginBase):
+    """
+    Override user-defined ack and shelve timeout values with server defaults.
+    """
+
+    def pre_receive(self, alert: 'Alert', **kwargs) -> 'Alert':
+        return alert
+
+    def post_receive(self, alert: 'Alert', **kwargs) -> Optional['Alert']:
+        return
+
+    def status_change(self, alert: 'Alert', status: str, text: str, **kwargs) -> Any:
+        return
+
+    def take_action(self, alert: 'Alert', action: str, text: str, **kwargs) -> Any:
+
+        timeout = kwargs['timeout']
+        if action == ChangeType.ack:
+            ack_timeout = self.get_config('ACK_TIMEOUT')
+            if timeout != ack_timeout:
+                LOG.warning('Override user-defined ack timeout of {} seconds to {} seconds.'.format(
+                    timeout, ack_timeout
+                ))
+                timeout = ack_timeout
+                text += ' (using server timeout value)'
+
+        if action == ChangeType.shelve:
+            shelve_timeout = self.get_config('SHELVE_TIMEOUT')
+            if timeout != shelve_timeout:
+                LOG.warning('Override user-defined shelve timeout of {} seconds to {} seconds.'.format(
+                    timeout, shelve_timeout
+                ))
+                timeout = shelve_timeout
+                text += ' (using server timeout value)'
+
+        return alert, action, text, timeout
+
+    def take_note(self, alert: 'Alert', text: Optional[str], **kwargs) -> Any:
+        raise NotImplementedError
+
+    def delete(self, alert: 'Alert', **kwargs) -> bool:
+        raise NotImplementedError

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,8 @@ setuptools.setup(
             'heartbeat = alerta.plugins.heartbeat:HeartbeatReceiver',
             'blackout = alerta.plugins.blackout:BlackoutHandler',
             'acked_by = alerta.plugins.acked_by:AckedBy',
-            'forwarder = alerta.plugins.forwarder:Forwarder'
+            'forwarder = alerta.plugins.forwarder:Forwarder',
+            'timeout = alerta.plugins.timeout:TimeoutPolicy'
         ],
         'alerta.webhooks': [
             'cloudwatch = alerta.webhooks.cloudwatch:CloudWatchWebhook',


### PR DESCRIPTION
If the `timeout` plugin is enabled it will enforce the service timeout policy for ack'ing and shelving alerts so that user-defined timeout values will be overridden by server default values.

```
            'PLUGINS': ['timeout'],
            'ACK_TIMEOUT': 98765,   # timeout values used no matter what timeout values sent by user
            'SHELVE_TIMEOUT': 12345
```
