### PR TITLE
fix root dictconfig key in logging.py

### DIFF
--- a/alerta/utils/logging.py
+++ b/alerta/utils/logging.py
@@ -98,10 +98,6 @@ class Logger:
                     }
                 },
                 'loggers': {
-                    'root': {
-                        'level': log_level,
-                        'handlers': app.config['LOG_HANDLERS'],
-                    },
                     'alerta': {
                         'level': log_level,
                     },
@@ -120,7 +116,11 @@ class Logger:
                     'werkzeug': {
                         'level': 'WARNING',
                     },
-                }
+                },
+                'root': {
+                    'level': log_level,
+                    'handlers': app.config['LOG_HANDLERS'],
+                },
             })
 
             # from logging_tree import printout


### PR DESCRIPTION
Submitting a fix for the root key in the dictconfig. According to https://docs.python.org/2/library/logging.config.html#dictionary-schema-details a root config should be it's own key outside of loggers. 