### PR TITLE
fix(auth): HMAC was falling thru to catchall if auth required

### DIFF
--- a/alerta/auth/decorators.py
+++ b/alerta/auth/decorators.py
@@ -63,6 +63,7 @@ def permission(scope=None):
                 g.login = receiver.parsed_header.get('id')
                 g.customers = []
                 g.scopes = ADMIN_SCOPES
+                return f(*args, **kwargs)
 
             # Bearer Token
             auth_header = request.headers.get('Authorization', '')

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -77,8 +77,8 @@ SIGNUP_ENABLED = True
 
 HMAC_AUTH_CREDENTIALS = [
     # {
-    #     'id': '',  # access key id  => $ uuidgen | tr '[:upper:]' '[:lower:]'
-    #     'key': '',  # secret key => $ date | md5 | base64
+    #     'key': '',  # access key id  => $ uuidgen | tr '[:upper:]' '[:lower:]'
+    #     'secret': '',  # secret key => $ date | md5 | base64
     #     'algorithm': 'sha256'  # valid hmac algorithm eg. sha256, sha384, sha512
     # }
 ]  # type: List[Dict[str, Any]]


### PR DESCRIPTION
Even though a request may have been successfully authenticated using HMAC if `AUTH_REQUIRED` was set to `True` it would always fail with a 401 error.