### PR TITLE
alerta_gitlab update

### DIFF
--- a/contrib/plugins/gitlab/alerta_gitlab.py
+++ b/contrib/plugins/gitlab/alerta_gitlab.py
@@ -24,7 +24,7 @@ class GitlabIssue(PluginBase):
         for tag in alert.tags:
             try:
                 k, v = tag.split('=', 1)
-                if k == "project_id":
+                if k == 'project_id':
                     alert.attributes['base_url'] = '{}/projects/{}'.format(GITLAB_URL, quote(v, safe=''))
             except ValueError:
                 pass

--- a/contrib/plugins/gitlab/alerta_gitlab.py
+++ b/contrib/plugins/gitlab/alerta_gitlab.py
@@ -49,7 +49,7 @@ class GitlabIssue(PluginBase):
                 due = '/due in 1 days \n'
                 assign = '/assign @all'
                 issue_iid = alert.attributes['issue_iid']
-                issue_body due + assign
+                issue_body = due + assign
                 dueurl = alert.attributes['base_url'] + '/issues/{}/discussions?body={}'.format(issue_iid, issue_body)
                 r1 = requests.post(dueurl, headers=self.headers)
         return alert
@@ -75,7 +75,7 @@ class GitlabIssue(PluginBase):
                 due = '/due in 1 days \n'
                 assign = '/assign @all'
                 issue_iid = alert.attributes['issue_iid']
-                issue_body due + assign
+                issue_body = due + assign
                 dueurl = alert.attributes['base_url'] + '/issues/{}/discussions?body={}'.format(issue_iid, issue_body)
                 r1 = requests.post(dueurl, headers=self.headers)
 

--- a/contrib/plugins/gitlab/alerta_gitlab.py
+++ b/contrib/plugins/gitlab/alerta_gitlab.py
@@ -1,8 +1,9 @@
 import logging
 import os
 from urllib.parse import quote
-
+from flask import g
 import requests
+import datetime
 
 from alerta.plugins import PluginBase, app
 
@@ -16,8 +17,6 @@ GITLAB_ACCESS_TOKEN = os.environ.get('GITLAB_PERSONAL_ACCESS_TOKEN') or app.conf
 class GitlabIssue(PluginBase):
 
     def __init__(self, name=None):
-
-        self.base_url = None
         self.headers = {'Private-Token': GITLAB_ACCESS_TOKEN}
         super().__init__()
 
@@ -25,13 +24,34 @@ class GitlabIssue(PluginBase):
         for tag in alert.tags:
             try:
                 k, v = tag.split('=', 1)
-                if k == 'project_id':
-                    self.base_url = '{}/projects/{}'.format(GITLAB_URL, quote(v, safe=''))
+                if k == "project_id":
+                    alert.attributes['base_url'] = '{}/projects/{}'.format(GITLAB_URL, quote(v, safe=''))
             except ValueError:
                 pass
         return alert
 
     def post_receive(self, alert, **kwargs):
+        starttime = alert.create_time
+        deadtime = starttime + datetime.timedelta(days=1)
+        lastreceivedtime = alert.last_receive_time
+        if (lastreceivedtime > deadtime):
+            if 'issue_iid' not in alert.attributes:
+                url = alert.attributes['base_url'] + '/issues?title=' + alert.text
+                r = requests.post(url, headers=self.headers)
+                alert.attributes['Open Issue User'] = g.login
+                alert.attributes['gitlab_result'] = r.text
+                alert.attributes['gitlab_status_code'] = r.status_code
+                alert.attributes['issue_iid'] = r.json().get('iid', None)
+                alert.attributes['gitlabUrl'] = '<a href="{}" target="_blank">Issue #{}</a>'.format(
+                    r.json().get('web_url', None),
+                    r.json().get('iid', None)
+                )
+                due = '/due in 1 days \n'
+                assign = '/assign @all'
+                issue_iid = alert.attributes['issue_iid']
+                issue_body due + assign
+                dueurl = alert.attributes['base_url'] + '/issues/{}/discussions?body={}'.format(issue_iid, issue_body)
+                r1 = requests.post(dueurl, headers=self.headers)
         return alert
 
     def status_change(self, alert, status, text, **kwargs):
@@ -39,25 +59,37 @@ class GitlabIssue(PluginBase):
 
     def take_action(self, alert, action, text, **kwargs):
         """should return internal id of external system"""
-        BASE_URL = '{}/projects/{}'.format(GITLAB_URL, quote(GITLAB_PROJECT_ID, safe=''))
 
         if action == 'createIssue':
             if 'issue_iid' not in alert.attributes:
-
-                if self.base_url:
-                    url = self.base_url + '/issues?title=' + alert.text
+                url = alert.attributes['base_url'] + '/issues?title=' + alert.text
                 r = requests.post(url, headers=self.headers)
+                alert.attributes['Open Issue User'] = g.login
+                alert.attributes['gitlab_result'] = r.text
+                alert.attributes['gitlab_status_code'] = r.status_code
                 alert.attributes['issue_iid'] = r.json().get('iid', None)
                 alert.attributes['gitlabUrl'] = '<a href="{}" target="_blank">Issue #{}</a>'.format(
                     r.json().get('web_url', None),
                     r.json().get('iid', None)
                 )
+                due = '/due in 1 days \n'
+                assign = '/assign @all'
+                issue_iid = alert.attributes['issue_iid']
+                issue_body due + assign
+                dueurl = alert.attributes['base_url'] + '/issues/{}/discussions?body={}'.format(issue_iid, issue_body)
+                r1 = requests.post(dueurl, headers=self.headers)
 
         elif action == 'updateIssue':
             if 'issue_iid' in alert.attributes:
-                issue_iid = alert.attributes['issue_iid']
                 body = 'Update: ' + alert.text
-                url = BASE_URL + '/issues/{}/discussions?body={}'.format(issue_iid, body)
+                issue_iid = alert.attributes['issue_iid']
+                url = alert.attributes['base_url'] + '/issues/{}/discussions?body={}'.format(issue_iid, body)
+                r = requests.post(url, headers=self.headers)
+
+        elif action == 'closeIssue':
+            if 'issue_iid' in alert.attributes:
+                issue_iid = alert.attributes['issue_iid']
+                url = alert.attributes['base_url'] + '/issues/{}/notes?body=closed\n/close'.format(issue_iid)
                 r = requests.post(url, headers=self.headers)
 
         return alert, action, text

--- a/contrib/plugins/gitlab/alerta_gitlab.py
+++ b/contrib/plugins/gitlab/alerta_gitlab.py
@@ -25,7 +25,7 @@ class GitlabIssue(PluginBase):
         for tag in alert.tags:
             try:
                 k, v = tag.split('=', 1)
-                if k == "project_id":
+                if k == 'project_id':
                     self.base_url = '{}/projects/{}'.format(GITLAB_URL, quote(v, safe=''))
             except ValueError:
                 pass


### PR DESCRIPTION
Update gitlab url and add project id via alertmanager tags. Example alertmanager alerts: 

groups:
- name: node-exporter
  rules:
  - alert: BootTimeTooHigh
    expr: node_boot_time_seconds > 0
    for: 1s
    labels:
      severity: security
      project_id: 149
      project_name: kalilinuxtr
    annotations:
      summary: "Boot time took too long on {{ $labels.instance }}"
      description: "{{ $labels.instance }} had a boot time of (current value: {{ $value }}s).  This is unacceptable :P"