### PR TITLE
Add support for custom auth scopes

### DIFF
--- a/alerta/app.py
+++ b/alerta/app.py
@@ -10,6 +10,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 from alerta.database.base import Database, QueryBuilder
 from alerta.exceptions import ExceptionHandlers
 from alerta.models.alarms import AlarmModel
+from alerta.models.enums import Scope
 from alerta.utils.audit import AuditTrail
 from alerta.utils.config import Config
 from alerta.utils.hooks import HookTrigger
@@ -58,6 +59,7 @@ def create_app(config_override: Dict[str, Any] = None, environment: str = None) 
     hooks.init_app(app)
     audit.init_app(app)
     alarm_model.init_app(app)
+    Scope.init_app(app)
 
     cors.init_app(app)
     compress.init_app(app)

--- a/alerta/auth/decorators.py
+++ b/alerta/auth/decorators.py
@@ -48,7 +48,7 @@ def permission(scope=None):
                 g.scopes = key_info.scopes  # type: List[Scope]
 
                 if not Permission.is_in_scope(scope, have_scopes=g.scopes):
-                    raise ApiError('Missing required scope: %s' % scope.value, 403)
+                    raise ApiError('Missing required scope: %s' % scope, 403)
                 else:
                     return f(*args, **kwargs)
 
@@ -85,7 +85,7 @@ def permission(scope=None):
                 g.scopes = jwt.scopes  # type: List[Scope]
 
                 if not Permission.is_in_scope(scope, have_scopes=g.scopes):
-                    raise ApiError('Missing required scope: %s' % scope.value, 403)
+                    raise ApiError('Missing required scope: %s' % scope, 403)
                 else:
                     return f(*args, **kwargs)
 
@@ -116,7 +116,7 @@ def permission(scope=None):
                 g.scopes = Permission.lookup(user.email, roles=user.roles)  # type: List[Scope]
 
                 if not Permission.is_in_scope(scope, have_scopes=g.scopes):
-                    raise BasicAuthError('Missing required scope: %s' % scope.value, 403)
+                    raise BasicAuthError('Missing required scope: %s' % scope, 403)
                 else:
                     return f(*args, **kwargs)
 

--- a/alerta/models/enums.py
+++ b/alerta/models/enums.py
@@ -1,3 +1,4 @@
+import re
 from enum import Enum
 
 
@@ -51,7 +52,7 @@ class TrendIndication(str, Enum):
     Less_Severe = 'lessSevere'
 
 
-class Scope(str, Enum):
+class Scope(str):
 
     read = 'read'
     write = 'write'
@@ -83,6 +84,25 @@ class Scope(str, Enum):
     admin_management = 'admin:management'
     read_userinfo = 'read:userinfo'
 
+    @staticmethod
+    def init_app(app):
+        for scope in app.config['CUSTOM_SCOPES']:
+            Scope.create(scope)
+
+    @classmethod
+    def create(cls, scope):
+
+        m = re.fullmatch(r'(admin|write|read|delete):(\w+)(\.\w+)?', scope)
+        if not m:
+            raise ValueError(f'Scopes must match "action:resource[.type]" eg. "read:foo.bar": {scope}')
+
+        name = re.sub('[:.]', '_', scope)
+        setattr(cls, name, scope)
+
+    @classmethod
+    def find_all(cls):
+        return [s for s in vars(Scope).values() if isinstance(s, str) and s.startswith(('admin', 'write', 'read', 'delete'))]
+
     @property
     def action(self):
         return self.split(':')[0]
@@ -90,20 +110,30 @@ class Scope(str, Enum):
     @property
     def resource(self):
         try:
-            return self.split(':')[1]
+            return self.split(':')[1].split('.')[0]
+        except IndexError:
+            return None
+
+    @property
+    def type(self):
+        try:
+            return self.split(':')[1].split('.')[1]
         except IndexError:
             return None
 
     @staticmethod
-    def from_str(action: str, resource: str = None):
-        """Return a scope based on the supplied action and resource.
+    def from_str(action: str, resource: str = None, type: str = None):
+        """Return a scope based on the supplied action, resource and type.
 
         :param action: the scope action eg. read, write, delete or admin
         :param resource: the specific resource of the scope, if any eg. alerts,
             blackouts, heartbeats, users, perms, customers, keys, webhooks,
             oembed, management or userinfo or None
+        :param type: the specific type of the resource
         :return: Scope
         """
+        if resource and type:
+            return Scope('{}:{}.{}'.format(action, resource, type))
         if resource:
             return Scope('{}:{}'.format(action, resource))
         else:

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -69,6 +69,7 @@ USER_DEFAULT_SCOPES = ['read', 'write']  # Note: 'write' scope implicitly includ
 DEFAULT_GUEST_ROLE = 'guest'
 GUEST_ROLES = [DEFAULT_GUEST_ROLE]
 GUEST_DEFAULT_SCOPES = ['read:alerts']
+CUSTOM_SCOPES = []
 DELETE_SCOPES = []  # Set to "delete:alerts" to prevent users with "write:alerts" scope being able to delete alerts
 CUSTOMER_VIEWS = False
 

--- a/alerta/views/permissions.py
+++ b/alerta/views/permissions.py
@@ -138,7 +138,7 @@ def update_perm(perm_id):
         raise ApiError('nothing to change', 400)
 
     for s in request.json.get('scopes', []):
-        if s not in list(Scope):
+        if s not in Scope.find_all():
             raise ApiError("'{}' is not a valid Scope".format(s), 400)
 
     perm = Permission.find_by_id(perm_id)
@@ -180,7 +180,7 @@ def delete_perm(perm_id):
 @permission(Scope.read_perms)
 @jsonp
 def list_scopes():
-    scopes = list(Scope)
+    scopes = Scope.find_all()
 
     return jsonify(
         status='ok',


### PR DESCRIPTION
*Example*
```
CUSTOM_SCOPES = ['admin:foo.bar', 'write:foo.bar', 'read:foo.bar', 'admin:bar']
```

```
{
    "scopes": [
        "read",
        "write",
        "admin",
        "read:alerts",
        "write:alerts",
        "admin:alerts",
        "read:blackouts",
        "write:blackouts",
        "admin:blackouts",
        "read:heartbeats",
        "write:heartbeats",
        "admin:heartbeats",
        "write:users",
        "admin:users",
        "read:groups",
        "admin:groups",
        "read:perms",
        "admin:perms",
        "read:customers",
        "admin:customers",
        "read:keys",
        "write:keys",
        "admin:keys",
        "write:webhooks",
        "read:oembed",
        "read:management",
        "admin:management",
        "read:userinfo",
        "admin:foo.bar",
        "write:foo.bar",
        "read:foo.bar",
        "admin:bar"
    ],
    "status": "ok",
    "total": 32
}

```

See #1475