### PR TITLE
feat: support readonly users

### DIFF
--- a/alerta/auth/decorators.py
+++ b/alerta/auth/decorators.py
@@ -120,11 +120,20 @@ def permission(scope=None):
                 else:
                     return f(*args, **kwargs)
 
+            # auth not required
             if not current_app.config['AUTH_REQUIRED']:
                 g.user_id = None
                 g.login = None
                 g.customers = []
                 g.scopes = []  # type: List[Scope]
+                return f(*args, **kwargs)
+
+            # auth required for admin/write, but readonly is allowed
+            if current_app.config['AUTH_REQUIRED'] and current_app.config['ALLOW_READONLY']:
+                g.user_id = None
+                g.login = None
+                g.customers = []
+                g.scopes = current_app.config['READONLY_SCOPES']
                 return f(*args, **kwargs)
 
             # Google App Engine Cron Service

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -73,6 +73,9 @@ CUSTOM_SCOPES = []
 DELETE_SCOPES = []  # Set to "delete:alerts" to prevent users with "write:alerts" scope being able to delete alerts
 CUSTOMER_VIEWS = False
 
+ALLOW_READONLY = False
+READONLY_SCOPES = ['read']
+
 BASIC_AUTH_REALM = 'Alerta'
 SIGNUP_ENABLED = True
 

--- a/alerta/views/config.py
+++ b/alerta/views/config.py
@@ -23,6 +23,8 @@ def config():
             }
         },
         'auth_required': current_app.config['AUTH_REQUIRED'],
+        'allow_readonly': current_app.config['ALLOW_READONLY'],
+        'readonly_scopes': current_app.config['READONLY_SCOPES'],
         'provider': current_app.config['AUTH_PROVIDER'],
         'customer_views': current_app.config['CUSTOMER_VIEWS'],
         'signup_enabled': current_app.config['SIGNUP_ENABLED'] if current_app.config['AUTH_PROVIDER'] == 'basic' else False,


### PR DESCRIPTION
To allow read-only logins, set the following ...
```
ALLOW_READONLY = True
READONLY_SCOPES = ['read']
```

For more fine-grained control over exactly which read-only scopes a user should have without logging in use ...
```
ALLOW_READONLY = True
READONLY_SCOPES = ['read:alert', 'read:heartbeats']
```

See alerta/alerta-webui#468