### PR TITLE
fix: config setting default environment for webhooks

### DIFF
--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -265,3 +265,6 @@ FWD_DESTINATIONS = [
 ]  # type: List[Tuple]
 
 # valid actions=['*', 'alerts', 'actions', 'open', 'assign', 'ack', 'unack', 'shelve', 'unshelve', 'close', 'delete']
+
+# Webhooks
+DEFAULT_ENVIRONMENT = 'Production'  # default environment used by webhooks, value must be in ALLOWED_ENVIRONMENTS

--- a/alerta/utils/config.py
+++ b/alerta/utils/config.py
@@ -86,12 +86,18 @@ class Config:
         config['ORIGIN_BLACKLIST'] = get_config('ORIGIN_BLACKLIST', default=[], type=list, config=config)
         config['ALLOWED_ENVIRONMENTS'] = get_config('ALLOWED_ENVIRONMENTS', default=[], type=list, config=config)
 
+        # webhooks
+        config['DEFAULT_ENVIRONMENT'] = get_config('DEFAULT_ENVIRONMENT', default=None, type=str, config=config)
+
         # Runtime config check
         if config['CUSTOMER_VIEWS'] and not config['AUTH_REQUIRED']:
             raise RuntimeError('Must enable authentication to use customer views')
 
         if config['CUSTOMER_VIEWS'] and not config['ADMIN_USERS']:
             raise RuntimeError('Customer views is enabled but there are no admin users')
+
+        if config['DEFAULT_ENVIRONMENT'] not in config['ALLOWED_ENVIRONMENTS']:
+            raise RuntimeError('Default environment "{}" not in list of allowed environments'.format(config['DEFAULT_ENVIRONMENT']))
 
         return config
 

--- a/alerta/webhooks/cloudwatch.py
+++ b/alerta/webhooks/cloudwatch.py
@@ -2,6 +2,8 @@ import json
 from datetime import datetime
 from typing import Any, Dict
 
+from flask import current_app
+
 from alerta.app import alarm_model
 from alerta.models.alert import Alert
 
@@ -34,7 +36,7 @@ class CloudWatchWebhook(WebhookBase):
             return Alert(
                 resource=notification['TopicArn'],
                 event=notification['Type'],
-                environment='Production',
+                environment=current_app.config['DEFAULT_ENVIRONMENT'],
                 severity='informational',
                 service=['Unknown'],
                 group='AWS/CloudWatch',

--- a/alerta/webhooks/grafana.py
+++ b/alerta/webhooks/grafana.py
@@ -2,6 +2,7 @@ import copy
 import json
 from typing import Any, Dict
 
+from flask import current_app
 from werkzeug.datastructures import ImmutableMultiDict, MultiDict
 
 from alerta.app import alarm_model, qb
@@ -17,7 +18,7 @@ JSON = Dict[str, Any]
 def parse_grafana(args: ImmutableMultiDict, alert: JSON, match: Dict[str, Any]) -> Alert:
 
     # get values from request params
-    environment = args.get('environment', 'Production')
+    environment = args.get('environment', current_app.config['DEFAULT_ENVIRONMENT'])
     alerting_severity = args.get('severity', 'major')
     service = args.getlist('service') or ['Grafana']
     group = args.get('group', 'Performance')

--- a/alerta/webhooks/graylog.py
+++ b/alerta/webhooks/graylog.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict
 
+from flask import current_app
+
 from alerta.models.alert import Alert
 
 from . import WebhookBase
@@ -18,7 +20,7 @@ class GraylogWebhook(WebhookBase):
         return Alert(
             resource=payload['stream']['title'],
             event=query_string.get('event', 'Alert'),
-            environment=query_string.get('environment', 'Development'),
+            environment=query_string.get('environment', current_app.config['DEFAULT_ENVIRONMENT']),
             service=query_string.get('service', 'test').split(','),
             severity=query_string.get('severity', 'critical'),
             value='n/a',

--- a/alerta/webhooks/newrelic.py
+++ b/alerta/webhooks/newrelic.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict
 
+from flask import current_app
+
 from alerta.models.alarms.alerta import SEVERITY_MAP
 from alerta.models.alert import Alert
 
@@ -54,7 +56,7 @@ class NewRelicWebhook(WebhookBase):
         return Alert(
             resource=resource,
             event=event,
-            environment='Production',
+            environment=current_app.config['DEFAULT_ENVIRONMENT'],
             severity=severity,
             status=status,
             service=[payload['account_name']],

--- a/alerta/webhooks/pingdom.py
+++ b/alerta/webhooks/pingdom.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict
 
+from flask import current_app
+
 from alerta.app import alarm_model
 from alerta.models.alert import Alert
 
@@ -28,7 +30,7 @@ class PingdomWebhook(WebhookBase):
             resource=payload['check_name'],
             event=payload['current_state'],
             correlate=['UP', 'DOWN'],
-            environment='Production',
+            environment=current_app.config['DEFAULT_ENVIRONMENT'],
             severity=severity,
             service=[payload['check_type']],
             group='Network',

--- a/alerta/webhooks/prometheus.py
+++ b/alerta/webhooks/prometheus.py
@@ -1,6 +1,8 @@
 import datetime
 from typing import Any, Dict
 
+from flask import current_app
+
 from alerta.app import alarm_model
 from alerta.exceptions import ApiError
 from alerta.models.alert import Alert
@@ -43,7 +45,7 @@ def parse_prometheus(alert: JSON, external_url: str) -> Alert:
     # labels
     resource = labels.pop('exported_instance', None) or labels.pop('instance', 'n/a')
     event = labels.pop('event', None) or labels.pop('alertname')
-    environment = labels.pop('environment', 'Production')
+    environment = labels.pop('environment', current_app.config['DEFAULT_ENVIRONMENT'])
     customer = labels.pop('customer', None)
     correlate = labels.pop('correlate').split(',') if 'correlate' in labels else None
     service = labels.pop('service', '').split(',')

--- a/alerta/webhooks/riemann.py
+++ b/alerta/webhooks/riemann.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict
 
+from flask import current_app
+
 from alerta.models.alert import Alert
 
 from . import WebhookBase
@@ -18,7 +20,7 @@ class RiemannWebhook(WebhookBase):
         return Alert(
             resource='{}-{}'.format(payload['host'], payload['service']),
             event=payload.get('event', payload['service']),
-            environment=payload.get('environment', 'Production'),
+            environment=payload.get('environment', current_app.config['DEFAULT_ENVIRONMENT']),
             severity=payload.get('state', 'unknown'),
             service=[payload['service']],
             group=payload.get('group', 'Performance'),

--- a/alerta/webhooks/serverdensity.py
+++ b/alerta/webhooks/serverdensity.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict
 
+from flask import current_app
+
 from alerta.models.alert import Alert
 
 from . import WebhookBase
@@ -23,7 +25,7 @@ class ServerDensityWebhook(WebhookBase):
         return Alert(
             resource=payload['item_name'],
             event=payload['alert_type'],
-            environment='Production',
+            environment=current_app.config['DEFAULT_ENVIRONMENT'],
             severity=severity,
             service=[payload['item_type']],
             group=payload['alert_section'],

--- a/alerta/webhooks/stackdriver.py
+++ b/alerta/webhooks/stackdriver.py
@@ -49,7 +49,7 @@ class StackDriverWebhook(WebhookBase):
         return Alert(
             resource=incident['resource_name'],
             event=incident['condition_name'],
-            environment=incident.get('environment', 'Production'),
+            environment=incident.get('environment', current_app.config['DEFAULT_ENVIRONMENT']),
             severity=severity,
             status=status,
             service=service,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,6 +63,7 @@ class ConfigTestCase(unittest.TestCase):
 
         with mod_env(
                 ALLOWED_ENVIRONMENTS=','.join(self.allowed_environments),
+                DEFAULT_ENVIRONMENT='Baz',
                 ALLOWED_GITHUB_ORGS=','.join(self.allowed_github_orgs),
                 # ALLOWED_GITLAB_GROUPS=','.join(self.allowed_gitlab_groups),
                 ALLOWED_KEYCLOAK_ROLES=','.join(self.allowed_keycloak_roles),


### PR DESCRIPTION
Example
```
ALLOWED_ENVIRONMENTS=['DEV', 'CODE', 'PROD', 'TEST', 'PERF', 'UAT', 'QA', 'STAGING']
DEFAULT_ENVIRONMENT='STAGING'
```

Fixes #1455