### PR TITLE
feat: add escalate severity custom action plugin

### DIFF
--- a/alerta/exceptions.py
+++ b/alerta/exceptions.py
@@ -52,7 +52,7 @@ class ForwardingLoop(BaseError):
 
 
 class InvalidAction(BaseError):
-    """Invalid or redundant action for the current alert status."""
+    """Invalid or redundant action for the current alert status or severity."""
     pass
 
 

--- a/alerta/plugins/escalate.py
+++ b/alerta/plugins/escalate.py
@@ -1,0 +1,58 @@
+import logging
+
+from alerta.app import alarm_model
+from alerta.exceptions import InvalidAction
+from alerta.plugins import PluginBase
+
+LOG = logging.getLogger('alerta.plugins')
+
+ACTION_ESCALATE = 'escalate'
+
+escalate_map = {}
+
+
+class EscalateSeverity(PluginBase):
+    """
+    Add "escalate" custom action to web UI and CLI and increase the severity
+    an alert to the next highest severity based on the configured alarm model.
+
+    Must add "escalate" to the list of enabled 'PLUGINS' and "escalate" to
+    the list of valid custom 'ACTIONS' in server settings.
+    """
+
+    def __init__(self):
+        # populate escalate severity map
+        for sev in alarm_model.Severity:
+            level = str(alarm_model.Severity[sev] + 1)
+            if level not in escalate_map:
+                escalate_map[level] = [sev]
+            else:
+                escalate_map[level].append(sev)
+        super().__init__()
+
+    def pre_receive(self, alert, **kwargs):
+        return alert
+
+    def post_receive(self, alert, **kwargs):
+        return
+
+    def status_change(self, alert, status, text, **kwargs):
+        return
+
+    def take_action(self, alert, action, text, **kwargs):
+
+        if action == ACTION_ESCALATE:
+            severity_level = str(alarm_model.Severity[alert.severity])
+            try:
+                alert.severity = escalate_map.get(severity_level)[0]
+                text = 'alert severity escalated'
+            except TypeError:
+                raise InvalidAction('Can not escalate alert severity beyond "{}".'.format(alert.severity))
+
+        return alert, action, text
+
+    def take_note(self, alert, text, **kwargs):
+        raise NotImplementedError
+
+    def delete(self, alert, **kwargs) -> bool:
+        raise NotImplementedError

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setuptools.setup(
             'heartbeat = alerta.plugins.heartbeat:HeartbeatReceiver',
             'blackout = alerta.plugins.blackout:BlackoutHandler',
             'acked_by = alerta.plugins.acked_by:AckedBy',
+            'escalate = alerta.plugins.escalate:EscalateSeverity',
             'forwarder = alerta.plugins.forwarder:Forwarder',
             'timeout = alerta.plugins.timeout:TimeoutPolicy'
         ],


### PR DESCRIPTION
    Add "escalate" custom action to web UI and CLI and increase the severity
    an alert to the next highest severity based on the configured alarm model.

    Must add "escalate" to the list of enabled 'PLUGINS' and "escalate" to
    the list of valid custom 'ACTIONS' in server settings.


Example settings ...
```
PLUGINS=['blackout', 'timeout', 'escalate']
ACTIONS = ['escalate']
```

<img width="1025" alt="Screenshot 2021-05-09 at 09 36 58" src="https://user-images.githubusercontent.com/615057/117564056-5a3fed80-b0aa-11eb-91da-21eb84fde3e5.png">

