### PR TITLE
Add Login Mapping for SAML auth

### DIFF
--- a/alerta/auth/saml.py
+++ b/alerta/auth/saml.py
@@ -80,7 +80,7 @@ def saml_response_from_idp():
     subject = authn_response.get_subject()
 
     name = current_app.config['SAML2_USER_NAME_FORMAT'].format(**dict(map(lambda x: (x[0], x[1][0]), identity.items())))
-    login = subject.text
+    login = identity[current_app.config['SAML2_LOGIN_ATTRIBUTE']][0]
     email = identity[current_app.config['SAML2_EMAIL_ATTRIBUTE']][0]
 
     # Create user if not yet there

--- a/alerta/auth/saml.py
+++ b/alerta/auth/saml.py
@@ -80,7 +80,10 @@ def saml_response_from_idp():
     subject = authn_response.get_subject()
 
     name = current_app.config['SAML2_USER_NAME_FORMAT'].format(**dict(map(lambda x: (x[0], x[1][0]), identity.items())))
-    login = identity[current_app.config['SAML2_LOGIN_ATTRIBUTE']][0]
+    if current_app.config['SAML2_LOGIN_ATTRIBUTE']:
+        login = identity[current_app.config['SAML2_LOGIN_ATTRIBUTE']][0]
+    else:
+        login = subject.text
     email = identity[current_app.config['SAML2_EMAIL_ATTRIBUTE']][0]
 
     # Create user if not yet there

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -149,6 +149,7 @@ SAML2_ENTITY_ID = None
 SAML2_METADATA_URL = None
 SAML2_USER_NAME_FORMAT = '{givenName} {surname}'
 SAML2_EMAIL_ATTRIBUTE = 'emailAddress'
+SAML2_LOGIN_ATTRIBUTE = 'identifier'
 SAML2_CONFIG = {}  # type: Dict[str, Any]
 ALLOWED_SAML2_GROUPS = ['*']
 

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -149,7 +149,7 @@ SAML2_ENTITY_ID = None
 SAML2_METADATA_URL = None
 SAML2_USER_NAME_FORMAT = '{givenName} {surname}'
 SAML2_EMAIL_ATTRIBUTE = 'emailAddress'
-SAML2_LOGIN_ATTRIBUTE = 'identifier'
+SAML2_LOGIN_ATTRIBUTE = None
 SAML2_CONFIG = {}  # type: Dict[str, Any]
 ALLOWED_SAML2_GROUPS = ['*']
 


### PR DESCRIPTION
This is a proposal to add a SAML attribute for login field in Alerta instead of subject.text.

#1453 