### PR TITLE
Change deprecated PyJWT argument

### DIFF
--- a/alerta/models/token.py
+++ b/alerta/models/token.py
@@ -45,7 +45,7 @@ class Jwt:
             json = jwt.decode(
                 token,
                 key=key or current_app.config['SECRET_KEY'],
-                verify=verify,
+                options={"verify_signature": verify}
                 algorithms=algorithm,
                 audience=current_app.config['OAUTH2_CLIENT_ID'] or current_app.config['SAML2_ENTITY_ID'] or absolute_url()
             )

--- a/alerta/models/token.py
+++ b/alerta/models/token.py
@@ -45,7 +45,7 @@ class Jwt:
             json = jwt.decode(
                 token,
                 key=key or current_app.config['SECRET_KEY'],
-                options={"verify_signature": verify}
+                options={"verify_signature": verify},
                 algorithms=algorithm,
                 audience=current_app.config['OAUTH2_CLIENT_ID'] or current_app.config['SAML2_ENTITY_ID'] or absolute_url()
             )


### PR DESCRIPTION
PyJWT removed the `verify` argument from `decode()` [with the 2.0.0 version](https://pyjwt.readthedocs.io/en/stable/changelog.html#dropped-deprecated-verify-param-in-jwt-decode) and an invocation was missed in [the commit adding PyJWT 2 support](https://github.com/alerta/alerta/commit/88e2c482f3f5c2df7ab79c44bf80db6f6e96da97).

This causes the following exception, but I'm not sure which auth settings are needed to reproduce:

```
[pid: 26|app: 0|req: 212/293] 172.18.0.1 () {44 vars in 916 bytes} [Thu Oct  7 17:46:15 2021] OPTIONS /api/alerts?status=open&status=ack&sort-by=severity&sort-by=lastReceiveTime&page=1&page-size=2
0 => generated 1 bytes in 2 msecs (HTTP/1.1 200) 6 headers in 202 bytes (1 switches on core 0)

2021-10-07 17:46:15,802 alerta.app[26]: [ERROR] decode() got an unexpected keyword argument 'verify' request_id=1aca03a0-f9fd-4e89-939d-7c2ac63e26cf ip=172.18.0.1
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/lib/python3.6/site-packages/flask_cors/decorator.py", line 128, in wrapped_function
    resp = make_response(f(*args, **kwargs))
  File "/usr/local/lib/python3.6/site-packages/alerta/auth/decorators.py", line 75, in wrapped
    jwt = Jwt.parse(token)
  File "/usr/local/lib/python3.6/site-packages/alerta/models/token.py", line 50, in parse
    audience=current_app.config['OAUTH2_CLIENT_ID'] or current_app.config['SAML2_ENTITY_ID'] or absolute_url()
TypeError: decode() got an unexpected keyword argument 'verify'

[pid: 26|app: 0|req: 213/294] 172.18.0.1 () {48 vars in 1552 bytes} [Thu Oct  7 17:46:15 2021] GET /api/alerts?status=open&status=ack&sort-by=severity&sort-by=lastReceiveTime&page=1&page-size=20 =
> generated 1039 bytes in 3 msecs (HTTP/1.1 500) 3 headers in 144 bytes (1 switches on core 0)
```