### PR TITLE
Use GitHub teams for role lookup

### DIFF
--- a/alerta/auth/github.py
+++ b/alerta/auth/github.py
@@ -16,10 +16,10 @@ from . import auth
 def github():
 
     if current_app.config['GITHUB_URL'] == 'https://github.com':
-        access_token_url = 'https://github.com/login/oauth/access_token'
+        token_endpoint = 'https://github.com/login/oauth/access_token'
         github_api_url = 'https://api.github.com'
     else:
-        access_token_url = current_app.config['GITHUB_URL'] + '/login/oauth/access_token'
+        token_endpoint = current_app.config['GITHUB_URL'] + '/login/oauth/access_token'
         github_api_url = current_app.config['GITHUB_URL'] + '/api/v3'
 
     client_lookup = dict(zip(
@@ -34,15 +34,21 @@ def github():
         'client_id': request.json['clientId'],
         'client_secret': client_secret,
     }
-    r = requests.post(access_token_url, data, headers={'Accept': 'application/json'})
+    r = requests.post(token_endpoint, data, headers={'Accept': 'application/json'})
     token = r.json()
 
-    headers = {'Authorization': f"token {token['access_token']}"}
-    r = requests.get(github_api_url + '/user', headers=headers)
-    profile = r.json()
+    try:
+        headers = {'Authorization': f"token {token['access_token']}"}
+        r = requests.get(github_api_url + '/user', headers=headers)
+        profile = r.json()
+    except Exception:
+        raise ApiError('No access token in OpenID Connect token response.')
+
+    r = requests.get(github_api_url + '/user/teams', headers=headers)  # list public and private Github orgs
+    profile['teams'] = [f"{t['organization']['login']}/{t['slug']}" for t in r.json()]
 
     r = requests.get(github_api_url + '/user/orgs', headers=headers)  # list public and private Github orgs
-    organizations = [o['login'] for o in r.json()]
+    profile['organizations'] = [o['login'] for o in r.json()]
 
     subject = str(profile['id'])
     name = profile['name']
@@ -50,6 +56,13 @@ def github():
     email = profile['email']
     email_verified = bool(email)
     picture = profile['avatar_url']
+
+    role_claim = current_app.config['GITHUB_ROLE_CLAIM']
+    group_claim = current_app.config['GITHUB_GROUP_CLAIM']
+    custom_claims = {
+        role_claim: profile.get(role_claim, []),
+        group_claim: profile.get(group_claim, []),
+    }
 
     login = username or email
     if not login:
@@ -63,21 +76,24 @@ def github():
     else:
         user.update(login=login, email=email)
 
+    roles = custom_claims[role_claim] + user.roles
+    groups = custom_claims[group_claim]
+
     if user.status != 'active':
         raise ApiError(f'User {login} is not active', 403)
 
-    if not_authorized('ALLOWED_GITHUB_ORGS', organizations):
+    if not_authorized('ALLOWED_GITHUB_ORGS', profile['organizations']) or not_authorized('ALLOWED_EMAIL_DOMAINS', groups=[user.domain]):
         raise ApiError(f'User {login} is not authorized', 403)
     user.update_last_login()
 
-    scopes = Permission.lookup(login, roles=user.roles + organizations)
-    customers = get_customers(login, groups=[user.domain] + organizations)
+    scopes = Permission.lookup(login, roles=roles)
+    customers = get_customers(login, groups=[user.domain] + groups)
 
     auth_audit_trail.send(current_app._get_current_object(), event='github-login', message='user login via GitHub',
-                          user=login, customers=customers, scopes=scopes, roles=user.roles, orgs=organizations,
+                          user=login, customers=customers, scopes=scopes, roles=user.roles, **custom_claims,
                           resource_id=subject, type='user', request=request)
 
     token = create_token(user_id=subject, name=name, login=login, provider='github',
-                         customers=customers, scopes=scopes, roles=user.roles, orgs=organizations,
+                         customers=customers, scopes=scopes, roles=user.roles, groups=profile['teams'], orgs=profile['organizations'],
                          email=email, email_verified=email_verified, picture=picture)
     return jsonify(token=token.tokenize())

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -99,6 +99,8 @@ COGNITO_DOMAIN = None
 
 # GitHub OAuth2
 GITHUB_URL = 'https://github.com'
+GITHUB_ROLE_CLAIM = 'teams'  # used in role mapping
+GITHUB_GROUP_CLAIM = 'organizations'  # used in customer mapping
 ALLOWED_GITHUB_ORGS = ['*']
 
 # GitLab OAuth2


### PR DESCRIPTION
Uses GitHub "teams" assigned to a user to map to Alerta "roles" (new), and GitHub "organisations" to map to Alerta "customers" (as before).

However, this can be customised using two new settings ...

```
GITHUB_ROLE_CLAIM = 'teams'  # used in role mapping
GITHUB_GROUP_CLAIM = 'organizations'  # used in customer mapping
```
So if it was desired to continue with the existing behaviour of only using "organisations" to map to Alerta "roles" then use the following settings ...

```
GITHUB_ROLE_CLAIM = 'organizations'  # used in role mapping
```

Fixes #1624 