### PR TITLE
Optionally print warnings if db create fails

### DIFF
--- a/alerta/database/backends/mongodb/base.py
+++ b/alerta/database/backends/mongodb/base.py
@@ -19,13 +19,25 @@ from .utils import Query
 
 class Backend(Database):
 
-    def create_engine(self, app, uri, dbname=None):
+    def create_engine(self, app, uri, dbname=None, raise_on_error=True):
         self.uri = uri
         self.dbname = dbname
 
         db = self.connect()
-        self._create_indexes(db)
-        self._update_lookups(db)
+
+        try:
+            self._create_indexes(db)
+        except Exception as e:
+            if raise_on_error:
+                raise
+            app.logger.warning(e)
+
+        try:
+            self._update_lookups(db)
+        except Exception as e:
+            if raise_on_error:
+                raise
+            app.logger.warning(e)
 
     def connect(self):
         self.client = MongoClient(self.uri)

--- a/alerta/database/base.py
+++ b/alerta/database/base.py
@@ -48,7 +48,8 @@ class Database(Base):
         self.__class__ = type('DatabaseImpl', (cls.Backend, Database), {})
 
         try:
-            self.create_engine(app, uri=app.config['DATABASE_URL'], dbname=app.config['DATABASE_NAME'])
+            self.create_engine(app, uri=app.config['DATABASE_URL'], dbname=app.config['DATABASE_NAME'],
+                               raise_on_error=app.config['DATABASE_RAISE_ON_ERROR'])
         except Exception as e:
             if app.config['DATABASE_RAISE_ON_ERROR']:
                 raise
@@ -56,7 +57,7 @@ class Database(Base):
 
         app.teardown_appcontext(self.teardown_db)
 
-    def create_engine(self, app, uri, dbname=None):
+    def create_engine(self, app, uri, dbname=None, raise_on_error=True):
         raise NotImplementedError('Database engine has no create_engine() method')
 
     def connect(self):


### PR DESCRIPTION
If it is not possible, for whatever reason, to create the database or indexes during startup then it can be done manually beforehand and then errors during startup can be ignored as warnings.

To ignore database errors during startup and continue instead of failing set the following...
```
DATABASE_RAISE_ON_ERROR=False
```

Fixes alerta/alerta-webui#457