### PR TITLE
Add support to authentication via HTTP Headers when using an webproxy

### DIFF
--- a/alerta/auth/__init__.py
+++ b/alerta/auth/__init__.py
@@ -30,6 +30,13 @@ class AuthBlueprint(Blueprint):
             except Exception as e:
                 raise RuntimeError(e)
 
+        if app.config['AUTH_PROVIDER'] in ['http_header']:
+            app.config['AUTH_HTTP_HEADER'] = True
+            assert app.config['HTTP_HEADER_P2P_TOKEN'], \
+                'Must set at least HTTP_HEADER_P2P_TOKEN to use http_header authentication module'
+            assert app.config['HTTP_HEADER_USER_FIELD'] in ['username', 'email'], \
+                'HTTP_HEADER_USER_FIELD must be either username or email'
+
         super().register(app, options)
 
 

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -92,6 +92,13 @@ OAUTH2_CLIENT_ID = ''  # OAuth2 client ID and secret
 OAUTH2_CLIENT_SECRET = ''
 ALLOWED_EMAIL_DOMAINS = ['*']
 
+# HTTP Headers Auth
+HTTP_HEADER_AUTH = False
+HTTP_HEADER_AUTH_FIELD = 'email'
+HTTP_HEADER_USER_HEADER = 'X-Forwarded-User'
+HTTP_HEADER_P2P_HEADER = 'X-Forwarded-Token'
+HTTP_HEADER_P2P_TOKEN = None
+
 # Amazon Cognito
 AWS_REGION = 'us-east-1'  # US East - N. Virginia (default)
 COGNITO_USER_POOL_ID = None


### PR DESCRIPTION
This PR Adds support to authenticate users via HTTP Headers when using an Webproxy like Nginx or Apache.

Currently when reversing-proxy the user auth info can't be forwarded to Alerta because it does not trust in any HTTP header but the Authorization provided by the client.

My motivation here is when we try to setup a Nginx in front of Alerta with mTLS set up, the user_dn/email address can be forwarded and accepted by Alerta when few settings are set accordingly.

It enables admins to configure a new auth provider followed by 4 new settings:

| Variable  | Description | Default |
| ------------- | ------------- | ------------- | 
| `HTTP_HEADER_AUTH_FIELD`  | Can be either username or email. This will be used by the provider for looking up the user when selecting it from Database.  | `email` |
| `HTTP_HEADER_USER_HEADER`  | The header the WebProxy should forward with the login information | `X-Forwarded-User` |
| `HTTP_HEADER_P2P_HEADER`  | The header the WebProxy should forward with the P2P token | `X-Forwarded-Token` |
| `HTTP_HEADER_P2P_TOKEN`  | The P2P token Alerta will validate in order to trust who's forwarding the request | "" |
