### PR TITLE
Add bson dependency, used by utils.format

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 bcrypt==3.2.0
 blinker==1.4
+bson==0.5.10
 cryptography==36.0.0
 Flask==2.0.2
 Flask-Compress==1.10.1


### PR DESCRIPTION
This adds bson==0.5.10, which is simply the version pip just gave me.