### PR TITLE
Bump support versions for Python and MongoDB

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -252,10 +252,10 @@ jobs:
             libldap2-dev \
             libsasl2-dev \
             xmlsec1
-      - name: Set up Python 3.x
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.7'
           architecture: 'x64'
       - name: Install dependencies
         id: install-deps

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = blinker,bson,click,flask,flask_compress,flask_cors,itsdangerous,jwt,ldap,lxml,mohawk,pkg_resources,psycopg2,pymongo,pyparsing,pytz,requests,requests_hawk,requests_mock,saml2,sentry_sdk,setuptools,werkzeug,yaml
+known_third_party = blinker,click,flask,flask_compress,flask_cors,itsdangerous,jwt,ldap,lxml,mohawk,pkg_resources,psycopg2,pymongo,pyparsing,pytz,requests,requests_hawk,requests_mock,saml2,sentry_sdk,setuptools,werkzeug,yaml

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Release 8 only supports Python 3.7 or higher.
 The only mandatory dependency is MongoDB or PostgreSQL. Everything else is optional.
 
 - Postgres version 10 or better
-- MongoDB version 4.0 or better (4.0.7 required for full query syntax support)
+- MongoDB version 4.2 or better
 
 Installation
 ------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ PyYAML==6.0
 requests==2.26.0
 requests_hawk==1.1.1
 sentry-sdk[flask]==1.5.0
+werkzeug==2.0.3

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setuptools.setup(
     url='https://github.com/guardian/alerta',
     license='Apache License 2.0',
     author='Nick Satterly',
-    author_email='nick.satterly@gmail.com',
+    author_email='nfsatterly@gmail.com',
     packages=setuptools.find_packages(exclude=['tests']),
     install_requires=[
         'bcrypt',
@@ -55,7 +55,7 @@ setuptools.setup(
         'sentry-sdk[flask]>=0.10.2',
     ],
     extras_require={
-        'mongodb': ['pymongo>=3.6,<4.0'],
+        'mongodb': ['pymongo>=3.9.0,<4.0'],
         'postgres': ['psycopg2']
     },
     include_package_data=True,
@@ -99,6 +99,7 @@ setuptools.setup(
         'Intended Audience :: System Administrators',
         'Intended Audience :: Telecommunications Industry',
         'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.7',

--- a/tests/test_blackouts.py
+++ b/tests/test_blackouts.py
@@ -685,11 +685,11 @@ class BlackoutsTestCase(unittest.TestCase):
         }
 
         # create new blackout with end time 1 second in the future
-        one_second_from_now = datetime.utcnow() + timedelta(seconds=1)
+        three_second_from_now = datetime.utcnow() + timedelta(seconds=3)
         blackout = {
             'environment': 'Production',
             'service': ['Core'],
-            'endTime': one_second_from_now.strftime('%Y-%m-%dT%H:%M:%S.000Z')
+            'endTime': three_second_from_now.strftime('%Y-%m-%dT%H:%M:%S.000Z')
         }
         response = self.client.post('/blackout', data=json.dumps(blackout), headers=self.headers)
         self.assertEqual(response.status_code, 201)
@@ -704,7 +704,7 @@ class BlackoutsTestCase(unittest.TestCase):
         alert_receive_time = data['alert']['receiveTime']
 
         # wait for blackout to expire
-        time.sleep(2)
+        time.sleep(5)
 
         # resend duplicate alert now that blackout has expired
         response = self.client.post('/alert', data=json.dumps(self.prod_alert), headers=self.headers)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,7 +1,7 @@
 import json
 import unittest
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from werkzeug.datastructures import MultiDict
 
@@ -196,10 +196,8 @@ class SearchTestCase(unittest.TestCase):
     @patch('alerta.database.backends.mongodb.utils.datetime')
     def test_blackouts_query(self, mock_datetime):
 
-        # mock datetime.utcnow()
         now = datetime(2021, 1, 17, 20, 58, 0)
-        mock_datetime.utcnow = MagicMock(return_value=now)
-        mock_datetime.strftime = datetime.strftime
+        mock_datetime.utcnow.return_value = now
 
         # ?status=expired&status=pending&page=2&page-size=20&sort-by=-startTime
         search_params = MultiDict([
@@ -340,9 +338,8 @@ class SearchTestCase(unittest.TestCase):
     @patch('alerta.database.backends.mongodb.utils.datetime')
     def test_keys_query(self, mock_datetime):
 
-        # mock datetime.utcnow()
         now = datetime(2021, 1, 17, 20, 58, 0)
-        mock_datetime.utcnow = MagicMock(return_value=now)
+        mock_datetime.utcnow.return_value = now
         mock_datetime.strftime = datetime.strftime
 
         self.maxDiff = None

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39}-{mongodb,postgres}
+envlist = py{37,38,39,310}-{mongodb,postgres}
 skip_missing_interpreters=true
 
 [testenv]


### PR DESCRIPTION
Python 3.10 is added as an explicitly supported Python version.

Mongo DB 4.0 is End of Life (as at April 2022) so 4.2 is the minimum supported version.
Pymongo 3.9 is the first version to support MongoDB 4.2 so it becomes the minimum required version.

Werkzeug is pinned to version 2.0.3 so that Flask 2.0 continues to work.

Some useful references on mocking in python...

https://docs.python.org/3/library/unittest.mock-examples.html#partial-mocking
https://medium.com/geekculture/right-way-to-test-mock-and-patch-in-python-b02138fc5040