### PR TITLE
fix get alerts by query condition 'type' error

### DIFF
--- a/alerta/database/backends/postgres/utils.py
+++ b/alerta/database/backends/postgres/utils.py
@@ -123,7 +123,7 @@ class Alerts(QueryBuilder):
         'tags': (None, 'tags', 1),  # sort-by
         'attributes': ('attributes', 'attributes', 1),
         'origin': ('origin', 'origin', 1),
-        'type': ('event', 'event', 1),
+        'type': ('type', 'type', 1),
         'createTime': ('create_time', 'create_time', -1),
         'timeout': ('timeout', 'timeout', 1),
         'rawData': ('raw_data', 'raw_data', 1),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 bcrypt==3.2.0
 blinker==1.4
-cryptography==36.0.0
+cryptography==37.0.2
 Flask==2.1.2
 Flask-Compress==1.10.1
 Flask-Cors==3.0.10


### PR DESCRIPTION
get alerts by query condition 'type' will be error because field map  error