### PR TITLE
Use group parameter of top10 API endpoints

### DIFF
--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -546,10 +546,14 @@ class Backend(Database):
         """
         return {s.status: s.count for s in self._fetchall(select, query.vars)}
 
-    def get_topn_count(self, query=None, group='event', topn=100):
+    def get_topn_count(self, query=None, topn=100):
         query = query or Query()
+        group = 'event'
+        if query.group:
+            group = query.group[0]
+
         select = """
-            SELECT event, COUNT(1) as count, SUM(duplicate_count) AS duplicate_count,
+            SELECT {group}, COUNT(1) as count, SUM(duplicate_count) AS duplicate_count,
                    array_agg(DISTINCT environment) AS environments, array_agg(DISTINCT svc) AS services,
                    array_agg(DISTINCT ARRAY[id, resource]) AS resources
               FROM alerts, UNNEST (service) svc
@@ -563,16 +567,18 @@ class Backend(Database):
                 'duplicateCount': t.duplicate_count,
                 'environments': t.environments,
                 'services': t.services,
-                f'{group}': t.event,
+                group: getattr(t, group),
                 'resources': [{'id': r[0], 'resource': r[1], 'href': absolute_url(f'/alert/{r[0]}')} for r in t.resources]
             } for t in self._fetchall(select, query.vars, limit=topn)
         ]
 
-    def get_topn_flapping(self, query=None, group='event', topn=100):
+    def get_topn_flapping(self, query=None, topn=100):
         query = query or Query()
+        if query.group:
+            group = query.group[0]
         select = """
             WITH topn AS (SELECT * FROM alerts WHERE {where})
-            SELECT topn.event, COUNT(1) as count, SUM(duplicate_count) AS duplicate_count,
+            SELECT topn.{group}, COUNT(1) as count, SUM(duplicate_count) AS duplicate_count,
                    array_agg(DISTINCT environment) AS environments, array_agg(DISTINCT svc) AS services,
                    array_agg(DISTINCT ARRAY[topn.id, resource]) AS resources
               FROM topn, UNNEST (service) svc, UNNEST (history) hist
@@ -586,7 +592,7 @@ class Backend(Database):
                 'duplicateCount': t.duplicate_count,
                 'environments': t.environments,
                 'services': t.services,
-                'event': t.event,
+                group: getattr(t, group),
                 'resources': [{'id': r[0], 'resource': r[1], 'href': absolute_url(f'/alert/{r[0]}')} for r in t.resources]
             } for t in self._fetchall(select, query.vars, limit=topn)
         ]


### PR DESCRIPTION
The top10 count and top10 flapping API endpoint documentation specifies that a group-by parameter can be provided to group by that value. https://docs.alerta.io/api/reference.html?highlight=top10

It appears that this value is ignored. The `get_topn_flapping` and `get_topn_count` do have a `group` argument, but it is never provided on any invocations.

This pull request gets the first column in the query grouping and uses that for the topn CTE queries. Removing the group argument to get_topn_flapping as unnecessary. I'm not sure if that was the original intention, but the query group is set by the group-by request argument.

This also uses the group column in the CTE selection and in the function output to ensure the JSON output matches the documentation.
