### PR TITLE
fix: auth bypass via registering through API when AUTH_PROVIDER != basic

### DIFF
--- a/alerta/auth/basic.py
+++ b/alerta/auth/basic.py
@@ -13,8 +13,9 @@ from . import auth
 @auth.route('/auth/signup', methods=['OPTIONS', 'POST'])
 @cross_origin(supports_credentials=True)
 def signup():
+    signup_enabled = current_app.config['SIGNUP_ENABLED'] if current_app.config['AUTH_PROVIDER'] == 'basic' else False
 
-    if not current_app.config['SIGNUP_ENABLED']:
+    if not signup_enabled:
         raise ApiError('user signup is disabled', 403)
 
     try:


### PR DESCRIPTION
**This fixes a major security concern.**

Before this change you were able to signup accounts through the API, even though you had `AUTH_PROVIDER` set to something other than `basic`. This is not allowed in the frontend:
https://github.com/alerta/alerta/blob/master/alerta/views/config.py#L30

**Fix:** backend matches frontend when it comes to whether or not signups are enabled.


