### PR TITLE
plugin data are not always updated

### DIFF
--- a/alerta/utils/api.py
+++ b/alerta/utils/api.py
@@ -66,7 +66,7 @@ def process_alert(alert: Alert) -> Alert:
 
     wanted_plugins, wanted_config = plugins.routing(alert)
 
-    updated = None
+    alert_was_updated: bool = False
     for plugin in wanted_plugins:
         if skip_plugins:
             break
@@ -83,8 +83,9 @@ def process_alert(alert: Alert) -> Alert:
                 logging.error(f"Error while running post-receive plugin '{plugin.name}': {str(e)}")
         if updated:
             alert = updated
+            alert_was_updated = True
 
-    if updated:
+    if alert_was_updated:
         alert.update_tags(alert.tags)
         alert.attributes = alert.update_attributes(alert.attributes)
 


### PR DESCRIPTION
If the last plugin in the chain is not returning the "alert" object, but just return "None" then none of the updated information from the other plugins are committed to the database. This pull check if just one plugin has made a change and after all modules are done it commits data to the db.
I assume this is the way it was intended to be..