### PR TITLE
Fix deprecation warning for flask json_encoder

### DIFF
--- a/alerta/app.py
+++ b/alerta/app.py
@@ -74,8 +74,9 @@ def create_app(config_override: Dict[str, Any] = None, environment: str = None) 
     plugins.register(app)
     custom_webhooks.register(app)
 
-    from alerta.utils.format import CustomJSONEncoder
-    app.json_encoder = CustomJSONEncoder
+    from alerta.utils.format import AlertaJsonProvider
+    app.json_provider_class = AlertaJsonProvider
+    app.json = AlertaJsonProvider(app)
 
     from alerta.views import api
     app.register_blueprint(api)

--- a/alerta/utils/format.py
+++ b/alerta/utils/format.py
@@ -2,7 +2,7 @@ import datetime
 import json
 import traceback
 from decimal import Decimal
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from flask.json.provider import JSONProvider
 
@@ -20,7 +20,7 @@ class AlertaJsonProvider(JSONProvider):
         kwargs.setdefault('sort_keys', self.sort_keys)
         return json.dumps(obj, **kwargs, cls=CustomJSONEncoder)
 
-    def loads(self, s: str | bytes, **kwargs):
+    def loads(self, s: Union[str, bytes], **kwargs):
         return json.loads(s, **kwargs)
 
 

--- a/alerta/utils/format.py
+++ b/alerta/utils/format.py
@@ -1,10 +1,27 @@
 import datetime
+import json
 import traceback
+from decimal import Decimal
 from typing import Any, Optional
 
-from flask import json
+from flask.json.provider import JSONProvider
 
 dt = datetime.datetime
+
+
+class AlertaJsonProvider(JSONProvider):
+    """JSON Provider for Flask app to use CustomJSONEncoder."""
+
+    ensure_ascii: bool = True
+    sort_keys: bool = True
+
+    def dumps(self, obj, **kwargs):
+        kwargs.setdefault('ensure_ascii', self.ensure_ascii)
+        kwargs.setdefault('sort_keys', self.sort_keys)
+        return json.dumps(obj, **kwargs, cls=CustomJSONEncoder)
+
+    def loads(self, s: str | bytes, **kwargs):
+        return json.loads(s, **kwargs)
 
 
 class CustomJSONEncoder(json.JSONEncoder):
@@ -23,6 +40,8 @@ class CustomJSONEncoder(json.JSONEncoder):
             return DateTime.iso8601(o)
         elif isinstance(o, datetime.timedelta):
             return int(o.total_seconds())
+        elif isinstance(o, Decimal):
+            return str(o)
         elif isinstance(o, (Alert, History)):
             return o.serialize
         elif isinstance(o, Exception):


### PR DESCRIPTION
This PR fixes the deprecation warnings for Flask `json_encoder` by providing a custom `JSONProvider`


```
DeprecationWarning: 'app.json_encoder' is deprecated and will be removed in Flask 2.3. Customize 'app.json_provider_class' or 'app.json' instead.
```