### PR TITLE
Fixes #1794 - Change postgres metrics column count to BIGINT

### DIFF
--- a/alerta/sql/schema.sql
+++ b/alerta/sql/schema.sql
@@ -145,6 +145,7 @@ CREATE TABLE IF NOT EXISTS metrics (
     CONSTRAINT metrics_pkey PRIMARY KEY ("group", name, type)
 );
 ALTER TABLE metrics ALTER COLUMN total_time TYPE BIGINT;
+ALTER TABLE metrics ALTER COLUMN count TYPE BIGINT;
 
 
 CREATE TABLE IF NOT EXISTS perms (


### PR DESCRIPTION
Change metrics column `count` from INTEGER to BIGINT
Fixes #1794 