### PR TITLE
Add CLIPBOARD_TEMPLATE setting

### DIFF
--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -221,7 +221,7 @@ COLUMNS = [
 ]
 SORT_LIST_BY = ['severity', 'lastReceiveTime']  # eg. newest='lastReceiveTime' or oldest='-createTime' (Note: minus means reverse)
 DEFAULT_FILTER = {'status': ['open', 'ack']}
-CLIPBOARD_TEMPLATE = ""
+CLIPBOARD_TEMPLATE = ''
 
 
 # Alert Status Indicators

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -221,6 +221,8 @@ COLUMNS = [
 ]
 SORT_LIST_BY = ['severity', 'lastReceiveTime']  # eg. newest='lastReceiveTime' or oldest='-createTime' (Note: minus means reverse)
 DEFAULT_FILTER = {'status': ['open', 'ack']}
+CLIPBOARD_TEMPLATE = ""
+
 
 # Alert Status Indicators
 ASI_SEVERITY = [

--- a/alerta/utils/config.py
+++ b/alerta/utils/config.py
@@ -103,6 +103,8 @@ class Config:
         # webhooks
         config['DEFAULT_ENVIRONMENT'] = get_config('DEFAULT_ENVIRONMENT', default=None, type=str, config=config)
 
+        config['CLIPBOARD_TEMPLATE'] = get_config('CLIPBOARD_TEMPLATE', default=None, type=str, config=config)
+
         # Runtime config check
         if config['CUSTOMER_VIEWS'] and not config['AUTH_REQUIRED']:
             raise RuntimeError('Must enable authentication to use customer views')

--- a/alerta/views/config.py
+++ b/alerta/views/config.py
@@ -69,5 +69,6 @@ def config():
         'actions': current_app.config['ACTIONS'],
         'tracking_id': current_app.config['GOOGLE_TRACKING_ID'],
         'refresh_interval': current_app.config['AUTO_REFRESH_INTERVAL'],
-        'environments': current_app.config['ALLOWED_ENVIRONMENTS']
+        'environments': current_app.config['ALLOWED_ENVIRONMENTS'],
+        'clipboard_template': current_app.config['CLIPBOARD_TEMPLATE'],
     })

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,6 +26,11 @@ class ConfigTestCase(unittest.TestCase):
         self.allowed_gitlab_groups = ['gl1', 'gl2']
         self.allowed_keycloak_roles = ['kc1', 'kc2']
         self.allowed_oidc_roles = ['oidc1', 'oidc2']
+        self.clipboard_template = """
+        {% if status=='closed' %}This alert is closed:{% else %}This alert is open:{% endif %}
+        [{{ environment | upper }}] {{ resource }}
+        {{ text }}
+        """
 
         with mod_env(
                 ALLOWED_ENVIRONMENTS=','.join(self.allowed_environments),
@@ -33,6 +38,7 @@ class ConfigTestCase(unittest.TestCase):
                 ALLOWED_GITHUB_ORGS=','.join(self.allowed_github_orgs),
                 # ALLOWED_GITLAB_GROUPS=','.join(self.allowed_gitlab_groups),
                 ALLOWED_KEYCLOAK_ROLES=','.join(self.allowed_keycloak_roles),
+                CLIPBOARD_TEMPLATE=self.clipboard_template
                 # ALLOWED_OIDC_ROLES=','.join(self.allowed_oidc_roles),
         ):
 
@@ -47,8 +53,10 @@ class ConfigTestCase(unittest.TestCase):
             self.assertTrue(data['customer_views'])
             self.assertListEqual(data['sort_by'], ['severity', 'lastReceiveTime'])
             self.assertEqual(data['environments'], self.allowed_environments)
+            self.assertEqual(data['clipboard_template'], self.clipboard_template)
 
             self.assertEqual(self.app.config['ALLOWED_GITHUB_ORGS'], self.allowed_github_orgs)
             # self.assertEqual(self.app.config['ALLOWED_GITLAB_GROUPS'], self.allowed_gitlab_groups)
             # self.assertEqual(self.app.config['ALLOWED_KEYCLOAK_ROLES'], self.allowed_keycloak_roles)
             self.assertEqual(self.app.config['ALLOWED_OIDC_ROLES'], self.allowed_keycloak_roles)
+            self.assertEqual(self.app.config['CLIPBOARD_TEMPLATE'], self.clipboard_template)


### PR DESCRIPTION
Only merge this if you decide to merge the PR in the frontend: https://github.com/alerta/alerta-webui/pull/555


**Description**
to allow for configuring this web console setting in the backend: https://github.com/alerta/alerta-webui/pull/555

**Changes**

- Add `CLIPBOARD_TEMPLATE` setting, which can be used to set a template used for formatting the AlertDetail copy-button

---

**Example:**

Provided following alert-json
```json
{
  "text": "this is a major alert",
  "environment": "prod"
}
```
and this template
```python
CLIPBOARD_TEMPLATE = """
[{{environment | upper}}] Alert!
{{text}}
"""
```
would put the following text in your clipboard
```
[PROD] Alert!
this is a major alert
```
