### PR TITLE
fix: hange ORDER BY no-op for Postgres 15

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,12 +66,12 @@ jobs:
           steps: ${{ toJson(steps) }}
         if: failure()
 
-  test-postgres14:
+  test-postgres15:
     runs-on: ubuntu-latest
 
     services:
       postgres:
-        image: postgres:14
+        image: postgres:15
         env:
           POSTGRES_DB: alerta
           POSTGRES_USER: postgres

--- a/alerta/database/backends/postgres/utils.py
+++ b/alerta/database/backends/postgres/utils.py
@@ -13,7 +13,7 @@ from alerta.utils.format import DateTime
 from .queryparser import QueryParser
 
 Query = namedtuple('Query', ['where', 'vars', 'sort', 'group'])
-Query.__new__.__defaults__ = ('1=1', {}, '(false)', 'status')  # type: ignore
+Query.__new__.__defaults__ = ('1=1', {}, '(select 1)', 'status')  # type: ignore
 
 
 EXCLUDE_FROM_QUERY = [
@@ -48,7 +48,7 @@ class QueryBuilder:
                 else:
                     sort.append(f'{column} {direction}')
         else:
-            sort.append('(false)')
+            sort.append('(select 1)')
         return sort
 
     @staticmethod


### PR DESCRIPTION
**Description**
Postgres 15 no longer supports "(false)" as an ORDER BY "no-op".

See https://stackoverflow.com/questions/37898880/is-it-possible-to-make-the-order-by-clause-a-no-op-without-excluding-it-entirely

Fixes #1778 and alerta/docker-alerta#412

**Changes**
Change the "no-op" to a value supported by all Postgres versions.

**Screenshots**
n/a

**Checklist**
- [x] Pull request is limited to a single purpose
- [x] Code style/formatting is consistent
- [x] All existing tests are passing
- [x] Added new tests related to change
- [x] No unnecessary whitespace changes

**Collaboration**
When a user creates a pull request from a fork that they own, the user
generally has the authority to decide if other users can commit to the
pull request's compare branch. If the pull request author wants greater
collaboration, they can grant maintainers of the upstream repository
(that is, anyone with push access to the upstream repository) permission
to commit to the pull request's compare branch

See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork

