### PR TITLE
Allow locating alerta routing component in any distribution package

### DIFF
--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -255,6 +255,9 @@ SERVER_VERSION = 'full'  # show/hide server version eg. full, major, off
 GOOGLE_TRACKING_ID = None
 AUTO_REFRESH_INTERVAL = 5000  # ms
 
+# Routing
+ROUTING_DIST = 'alerta-routing'
+
 # Plugins
 PLUGINS = ['remote_ip', 'reject', 'heartbeat', 'blackout', 'forwarder']
 PLUGINS_RAISE_ON_ERROR = True  # raise RuntimeError exception on first failure

--- a/alerta/utils/plugin.py
+++ b/alerta/utils/plugin.py
@@ -44,7 +44,8 @@ class Plugins:
                 LOG.error(f"Failed to load plugin '{name}': {str(e)}")
         LOG.info(f"All server plugins enabled: {', '.join(self.plugins.keys())}")
         try:
-            self.rules = load_entry_point('alerta-routing', 'alerta.routing', 'rules')  # type: ignore
+            routing_dist = self.config['ROUTING_DIST']
+            self.rules = load_entry_point(routing_dist, 'alerta.routing', 'rules')  # type: ignore
         except (DistributionNotFound, ImportError):
             LOG.info('No plugin routing rules found. All plugins will be evaluated.')
 


### PR DESCRIPTION
**Description**
Currently, routing plugin must be located in a 'alerta-routing" python distribution package.
With this modification, that limitation is removed, allowing to use any distribution package name, configured with the property 'ROUTING_DIST'.

This way, plugins, routing, backend components,... may be located in one python distribution package.

**Changes**
Adds a new configuration property 'ROUTING_DIST' that is used to get the name
of the distribution package used to find routing component. 
Default value is 'alerta-routing' to make code compatible with current version.

