### PR TITLE
add db schema

### DIFF
--- a/alerta/database/backends/mongodb/base.py
+++ b/alerta/database/backends/mongodb/base.py
@@ -19,7 +19,7 @@ from .utils import Query
 
 class Backend(Database):
 
-    def create_engine(self, app, uri, dbname=None, raise_on_error=True):
+    def create_engine(self, app, uri, dbname=None, schema=None, raise_on_error=True):
         self.uri = uri
         self.dbname = dbname
 

--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -71,9 +71,6 @@ class Backend(Database):
         with lock:
             conn = self.connect()
 
-            conn.cursor().execute("SET search_path TO {}".format(self.schema))
-            conn.commit()
-
             with app.open_resource('sql/schema.sql') as f:
                 try:
                     conn.cursor().execute(f.read())
@@ -118,6 +115,8 @@ class Backend(Database):
                     time.sleep(backoff)
 
         if conn:
+            conn.cursor().execute("SET search_path TO {}".format(self.schema))
+            conn.commit()
             return conn
         else:
             raise RuntimeError(f'Database connect error. Failed to connect after {MAX_RETRIES} retries.')

--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -62,7 +62,7 @@ Record = namedtuple('Record', [
 
 class Backend(Database):
 
-    def create_engine(self, app, uri, dbname=None, schema=None, raise_on_error=True):
+    def create_engine(self, app, uri, dbname=None, schema='public', raise_on_error=True):
         self.uri = uri
         self.dbname = dbname
         self.schema = schema

--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -84,7 +84,6 @@ class Backend(Database):
                         raise
                     app.logger.warning(e)
 
-        print(schema + '.history' if schema else 'history')
         register_adapter(dict, Json)
         register_adapter(datetime, self._adapt_datetime)
         register_composite(

--- a/alerta/database/base.py
+++ b/alerta/database/base.py
@@ -56,7 +56,7 @@ class Database(Base):
         self.__class__ = type('DatabaseImpl', (cls.Backend, Database), {})
 
         try:
-            self.create_engine(app, uri=app.config['DATABASE_URL'], dbname=app.config['DATABASE_NAME'],
+            self.create_engine(app, uri=app.config['DATABASE_URL'], dbname=app.config['DATABASE_NAME'], schema=app.config['DATABASE_SCHEMA'],
                                raise_on_error=app.config['DATABASE_RAISE_ON_ERROR'])
         except Exception as e:
             if app.config['DATABASE_RAISE_ON_ERROR']:
@@ -65,7 +65,7 @@ class Database(Base):
 
         app.teardown_appcontext(self.teardown_db)
 
-    def create_engine(self, app, uri, dbname=None, raise_on_error=True):
+    def create_engine(self, app, uri, dbname=None, schema=None, raise_on_error=True):
         raise NotImplementedError('Database engine has no create_engine() method')
 
     def connect(self):

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -45,6 +45,7 @@ POSTGRES_DB = None
 DATABASE_URL = MONGO_URI  # default: MongoDB
 DATABASE_NAME = MONGO_DATABASE or POSTGRES_DB
 DATABASE_RAISE_ON_ERROR = MONGO_RAISE_ON_ERROR  # True - terminate, False - ignore and continue
+DATABASE_SCHEMA = None  # default: None to use default schema
 
 # Search
 DEFAULT_FIELD = 'text'  # default field if no search prefix specified (Postgres only)

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -45,7 +45,7 @@ POSTGRES_DB = None
 DATABASE_URL = MONGO_URI  # default: MongoDB
 DATABASE_NAME = MONGO_DATABASE or POSTGRES_DB
 DATABASE_RAISE_ON_ERROR = MONGO_RAISE_ON_ERROR  # True - terminate, False - ignore and continue
-DATABASE_SCHEMA = None  # default: None to use default schema
+DATABASE_SCHEMA = 'public'  # default: None to use default schema
 
 # Search
 DEFAULT_FIELD = 'text'  # default field if no search prefix specified (Postgres only)

--- a/alerta/sql/schema.sql
+++ b/alerta/sql/schema.sql
@@ -1,7 +1,7 @@
 
 DO $$
 BEGIN
-    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'history') THEN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'history' AND typnamespace = (SELECT oid FROM pg_namespace WHERE nspname = current_schema())) THEN
         CREATE TYPE history AS (
             id text,
             event text,

--- a/alerta/utils/config.py
+++ b/alerta/utils/config.py
@@ -38,6 +38,7 @@ class Config:
         # Use app config for DATABASE_URL if no env var from above override it
         config['DATABASE_URL'] = get_config('DATABASE_URL', default=database_url, type=str, config=config)
         config['DATABASE_NAME'] = get_config('DATABASE_NAME', default=None, type=str, config=config)
+        config['DATABASE_SCHEMA'] = get_config('DATABASE_SCHEMA', default=None, type=str, config=config)
 
         config['AUTH_REQUIRED'] = get_config('AUTH_REQUIRED', default=None, type=bool, config=config)
         config['AUTH_PROVIDER'] = get_config('AUTH_PROVIDER', default=None, type=str, config=config)

--- a/alerta/utils/config.py
+++ b/alerta/utils/config.py
@@ -38,7 +38,7 @@ class Config:
         # Use app config for DATABASE_URL if no env var from above override it
         config['DATABASE_URL'] = get_config('DATABASE_URL', default=database_url, type=str, config=config)
         config['DATABASE_NAME'] = get_config('DATABASE_NAME', default=None, type=str, config=config)
-        config['DATABASE_SCHEMA'] = get_config('DATABASE_SCHEMA', default=None, type=str, config=config)
+        config['DATABASE_SCHEMA'] = get_config('DATABASE_SCHEMA', default='public', type=str, config=config)
 
         config['AUTH_REQUIRED'] = get_config('AUTH_REQUIRED', default=None, type=bool, config=config)
         config['AUTH_PROVIDER'] = get_config('AUTH_PROVIDER', default=None, type=str, config=config)


### PR DESCRIPTION
I made a mistake, I closed this issue: https://github.com/alerta/alerta/pull/1799

**Description**
This change will allow the user to use a schema other than public in Postgres.

Fixes # (issue)

**Changes**
I added this: `schema + '.history' if schema else 'history',` in the `register_composite`. I modified some function parameters to take into account the schema.
I added `DATABASE_SCHEMA` in the environment variables.

**Screenshots**
![dockercompose](https://user-images.githubusercontent.com/114667166/232724620-29c63c55-4b0a-4ab9-a874-ae8a8c47fd0f.png)
![insomia2](https://user-images.githubusercontent.com/114667166/232724624-226d36b9-5f43-4431-8972-520106132b5a.PNG)
![insomia3](https://user-images.githubusercontent.com/114667166/232724625-1102cc9f-5051-4733-af29-6d44edb567d4.PNG)
![insomiaPNG](https://user-images.githubusercontent.com/114667166/232724627-d930c775-b0a7-47a5-b33a-05da554b5d40.PNG)
![powershell](https://user-images.githubusercontent.com/114667166/232724629-9a3fca1f-cce0-4e01-9ace-06a841d44048.png)
list**

