### PR TITLE
Add env variable to fix #1845

### DIFF
--- a/alerta/webhooks/prometheus.py
+++ b/alerta/webhooks/prometheus.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 from typing import Any, Dict
 
 from flask import current_app
@@ -15,6 +16,7 @@ dt = datetime.datetime
 
 def parse_prometheus(alert: JSON, external_url: str) -> Alert:
 
+    text_annotaion_key = os.environ.get('PROMETHEUS_TEXT_KEY') or current_app.config.get('PROMETHEUS_TEXT_KEY')
     status = alert.get('status', 'firing')
 
     # Allow labels and annotations to use python string formats that refer to
@@ -67,7 +69,10 @@ def parse_prometheus(alert: JSON, external_url: str) -> Alert:
     value = annotations.pop('value', None)
     summary = annotations.pop('summary', None)
     description = annotations.pop('description', None)
-    text = description or summary or f'{severity.upper()}: {resource} is {event}'
+    if text_annotaion_key:
+        text = annotations.pop(text_annotaion_key, None)
+    else:
+        text = description or summary or f'{severity.upper()}: {resource} is {event}'
 
     if external_url:
         annotations['externalUrl'] = external_url  # needed as raw URL for bi-directional integration


### PR DESCRIPTION
- Add PROMETHEUS_TEXT_KEY
- Use PROMETHEUS_TEXT_KEY to override text default value.

**Description**
The users will be able to use the environment variable PROMETHEUS_TEXT_KEY to redefine the text that "Alerta" will display as a description.

Fixes #1845 

**Changes**
Include a brief summary of changes...
- Get value from environment variable PROMETHEUS_TEXT_KEY or config file;
- In case the variable is defined, it will override the default value


**Checklist**
- [ x] Pull request is limited to a single purpose
- [ x] Code style/formatting is consistent
- [ x] All existing tests are passing
- [ ] Added new tests related to the change
- [ x] No unnecessary whitespace changes

**Collaboration**
When a user creates a pull request from a fork that they own, the user
generally has the authority to decide if other users can commit to the
pull request's compare branch. If the pull request author wants greater
collaboration, they can grant maintainers of the upstream repository
(that is, anyone with push access to the upstream repository) permission
to commit to the pull request's compare branch

See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork

