### PR TITLE
`token_endpoint_auth_methods_supported` is optional

### DIFF
--- a/alerta/auth/oidc.py
+++ b/alerta/auth/oidc.py
@@ -76,10 +76,11 @@ def openid():
         'redirect_uri': request.json['redirectUri'],
     }
 
-    if type(oidc_configuration['token_endpoint_auth_methods_supported']) == list:
-        token_endpoint_auth_methods = oidc_configuration['token_endpoint_auth_methods_supported']
-    else:
-        token_endpoint_auth_methods = [oidc_configuration['token_endpoint_auth_methods_supported']]
+    token_endpoint_auth_methods = oidc_configuration.get(
+                                     'token_endpoint_auth_methods_supported',
+                                     ['client_secret_basic'])
+    if type(token_endpoint_auth_methods) != list:
+        token_endpoint_auth_methods = [token_endpoint_auth_methods]
 
     preferred_token_auth_method = 'client_secret_post'
     for token_auth_method in current_app.config['OIDC_TOKEN_AUTH_METHODS']:


### PR DESCRIPTION
**Description**
The OIDC client implementation in alerta doesn't follow OIDC specification, causing compatibility problems (e.g. with gitea). More specifically, `token_endpoint_auth_methods_supported` is optional and defaults to `client_secret_basic`.

Fixes # (issue)
There is no issue open about this.

**Changes**
- make `token_endpoint_auth_methods_supported` optional and default to `client_secret_basic`
- refactoring to simplify code around it. I'm not sure I got the whitespace right, but it looks ugly if I use a larger indent

**Screenshots**
No UI change.

**Checklist**
- [x] Pull request is limited to a single purpose
- [x] Code style/formatting is consistent
- [ ] All existing tests are passing
- [ ] Added new tests related to change
- [ ] No unnecessary whitespace changes

**Collaboration**
Give me feedback, I can change the code.