### PR TITLE
Reject alerts that do not regex.fullmatch any configured allowed envi…

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = blinker,click,flask,flask_compress,flask_cors,itsdangerous,jwt,ldap,lxml,mohawk,pkg_resources,psycopg2,pymongo,pyparsing,pytz,requests,requests_hawk,requests_mock,saml2,sentry_sdk,setuptools,werkzeug,yaml
+known_third_party = blinker,click,flask,flask_compress,flask_cors,itsdangerous,jwt,ldap,lxml,mohawk,pkg_resources,psycopg2,pymongo,pyparsing,pytest,pytz,requests,requests_hawk,requests_mock,saml2,sentry_sdk,setuptools,werkzeug,yaml

--- a/alerta/plugins/reject.py
+++ b/alerta/plugins/reject.py
@@ -28,7 +28,7 @@ class RejectPolicy(PluginBase):
             LOG.warning("[POLICY] Alert origin '%s' has been blacklisted", alert.origin)
             raise RejectException(f"[POLICY] Alert origin '{alert.origin}' has been blacklisted")
 
-        if not any(regex.match(alert.environment) for regex in ALLOWED_ENVIRONMENT_REGEX):
+        if not any(regex.fullmatch(alert.environment) for regex in ALLOWED_ENVIRONMENT_REGEX):
             LOG.warning('[POLICY] Alert environment does not match one of %s', ', '.join(ALLOWED_ENVIRONMENTS))
             raise RejectException('[POLICY] Alert environment does not match one of %s' %
                                   ', '.join(ALLOWED_ENVIRONMENTS))

--- a/tests/plugins/test_reject.py
+++ b/tests/plugins/test_reject.py
@@ -1,4 +1,3 @@
-import unittest
 import unittest.mock as mock
 
 import pytest

--- a/tests/plugins/test_reject.py
+++ b/tests/plugins/test_reject.py
@@ -10,7 +10,7 @@ from alerta.plugins.reject import RejectPolicy
 TEST_ORIGIN_BLACKLISTS = []
 
 TEST_ALLOWED_ENVIRONMENTS = [
-    "test_env",
+    'test_env',
 ]
 
 
@@ -19,11 +19,11 @@ def reject_policy():
     reject = RejectPolicy()
 
     def mock_get_config(name, default, type, **kwargs):
-        if name == "ORIGIN_BLACKLIST":
+        if name == 'ORIGIN_BLACKLIST':
             return TEST_ORIGIN_BLACKLISTS
-        elif name == "ALLOWED_ENVIRONMENTS":
+        elif name == 'ALLOWED_ENVIRONMENTS':
             return TEST_ALLOWED_ENVIRONMENTS
-        raise Exception("Bad name")
+        raise Exception('Bad name')
 
     reject.get_config = mock.Mock(
         spec=RejectPolicy.get_config, side_effect=mock_get_config
@@ -33,11 +33,11 @@ def reject_policy():
 
 def test_reject_policy_allowed(reject_policy):
     allowed_alert = Alert(
-        "test_resource",
-        "test_event",
-        environment="test_env",
+        'test_resource',
+        'test_event',
+        environment='test_env',
         timeout=5,
-        service=["test_service"],
+        service=['test_service'],
     )
     returned_alert = reject_policy.pre_receive(allowed_alert)
     assert returned_alert == allowed_alert
@@ -46,25 +46,25 @@ def test_reject_policy_allowed(reject_policy):
 def test_reject_policy_rejected(reject_policy):
     reject_alerts = [
         Alert(
-            "test_resource",
-            "test_event",
-            environment="prod",
+            'test_resource',
+            'test_event',
+            environment='prod',
             timeout=5,
-            service=["test_service"],
+            service=['test_service'],
         ),
         Alert(
-            "test_resource",
-            "test_event",
-            environment="test",
+            'test_resource',
+            'test_event',
+            environment='test',
             timeout=5,
-            service=["test_service"],
+            service=['test_service'],
         ),
         Alert(
-            "test_resource",
-            "test_event",
-            environment="test_environment",
+            'test_resource',
+            'test_event',
+            environment='test_environment',
             timeout=5,
-            service=["test_service"],
+            service=['test_service'],
         ),
     ]
 

--- a/tests/plugins/test_reject.py
+++ b/tests/plugins/test_reject.py
@@ -1,0 +1,73 @@
+import unittest
+import unittest.mock as mock
+
+import pytest
+
+from alerta.exceptions import RejectException
+from alerta.models.alert import Alert
+from alerta.plugins.reject import RejectPolicy
+
+TEST_ORIGIN_BLACKLISTS = []
+
+TEST_ALLOWED_ENVIRONMENTS = [
+    "test_env",
+]
+
+
+@pytest.fixture
+def reject_policy():
+    reject = RejectPolicy()
+
+    def mock_get_config(name, default, type, **kwargs):
+        if name == "ORIGIN_BLACKLIST":
+            return TEST_ORIGIN_BLACKLISTS
+        elif name == "ALLOWED_ENVIRONMENTS":
+            return TEST_ALLOWED_ENVIRONMENTS
+        raise Exception("Bad name")
+
+    reject.get_config = mock.Mock(
+        spec=RejectPolicy.get_config, side_effect=mock_get_config
+    )
+    return reject
+
+
+def test_reject_policy_allowed(reject_policy):
+    allowed_alert = Alert(
+        "test_resource",
+        "test_event",
+        environment="test_env",
+        timeout=5,
+        service=["test_service"],
+    )
+    returned_alert = reject_policy.pre_receive(allowed_alert)
+    assert returned_alert == allowed_alert
+
+
+def test_reject_policy_rejected(reject_policy):
+    reject_alerts = [
+        Alert(
+            "test_resource",
+            "test_event",
+            environment="prod",
+            timeout=5,
+            service=["test_service"],
+        ),
+        Alert(
+            "test_resource",
+            "test_event",
+            environment="test",
+            timeout=5,
+            service=["test_service"],
+        ),
+        Alert(
+            "test_resource",
+            "test_event",
+            environment="test_environment",
+            timeout=5,
+            service=["test_service"],
+        ),
+    ]
+
+    for alert in reject_alerts:
+        with pytest.raises(RejectException):
+            reject_policy.pre_receive(alert)


### PR DESCRIPTION
…ronments

**Description**
A clear and concise description of **why** this change is necessary.

Fixes [#375](https://github.com/alerta/alerta-contrib/issues/375)

**Changes**
Makes `RejectPolicy` more strict about matching allowed environments via `regex.fullmatch`.

**Checklist**
- [x] Pull request is limited to a single purpose
- [x] Code style/formatting is consistent
- [ ] All existing tests are passing
- [x] Added new tests related to change
- [x] No unnecessary whitespace changes
