### PR TITLE
Add query string for blackouts

### DIFF
--- a/alerta/database/backends/mongodb/utils.py
+++ b/alerta/database/backends/mongodb/utils.py
@@ -220,8 +220,21 @@ class Blackouts(QueryBuilder):
     @staticmethod
     def from_params(params: ImmutableMultiDict, customers=None, query_time=None):
 
-        query = dict()  # type: Dict[str, Any]
         params = MultiDict(params)  # type: ignore
+
+        # ?q=
+        if params.get('q', None):
+            try:
+                parser = QueryParser()
+                query = json.loads(parser.parse(
+                    query=params['q'],
+                    default_field=params.get('q.df'),
+                    default_operator=params.get('q.op')
+                ))
+            except ParseException as e:
+                raise ApiError('Failed to parse query string.', 400, [e])
+        else:
+            query = dict()
 
         # customer
         if customers:

--- a/alerta/database/backends/postgres/utils.py
+++ b/alerta/database/backends/postgres/utils.py
@@ -224,9 +224,22 @@ class Blackouts(QueryBuilder):
     @staticmethod
     def from_params(params: MultiDict, customers=None, query_time=None):
 
-        query = ['1=1']
-        qvars = dict()
         params = MultiDict(params)
+
+        # ?q=
+        if params.get('q', None):
+            try:
+                parser = QueryParser()
+                query = [parser.parse(
+                    query=params['q'],
+                    default_field=params.get('q.df')
+                )]
+                qvars = dict()  # type: Dict[str, Any]
+            except ParseException as e:
+                raise ApiError('Failed to parse query string.', 400, [e])
+        else:
+            query = ['1=1']
+            qvars = dict()
 
         # customer
         if customers:


### PR DESCRIPTION
**Description**
Currently, search in UI is performed on the client-side. This change allows searching blackouts the same way as alerts.

**Changes**
Add `?q=` parameter in the blackouts API

**Screenshots**
If it's a UI change add screenshots to demonstrate changes.

**Checklist**
- [x] Pull request is limited to a single purpose
- [x] Code style/formatting is consistent
- [ ] All existing tests are passing
- [ ] Added new tests related to change
- [ ] No unnecessary whitespace changes

**Collaboration**
When a user creates a pull request from a fork that they own, the user
generally has the authority to decide if other users can commit to the
pull request's compare branch. If the pull request author wants greater
collaboration, they can grant maintainers of the upstream repository
(that is, anyone with push access to the upstream repository) permission
to commit to the pull request's compare branch

See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork

