### PR TITLE
Address breaking change in Python 3.11 for Enums with `str` mixins

### DIFF
--- a/alerta/models/blackout.py
+++ b/alerta/models/blackout.py
@@ -1,9 +1,9 @@
 from datetime import datetime, timedelta
-from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Union
 from uuid import uuid4
 
 from flask import current_app
+from strenum import StrEnum
 
 from alerta.app import db
 from alerta.database.base import Query
@@ -13,7 +13,7 @@ from alerta.utils.response import absolute_url
 JSON = Dict[str, Any]
 
 
-class BlackoutStatus(str, Enum):
+class BlackoutStatus(StrEnum):
 
     Pending = 'pending'
     Active = 'active'

--- a/alerta/models/enums.py
+++ b/alerta/models/enums.py
@@ -1,8 +1,9 @@
 import re
-from enum import Enum
+
+from strenum import StrEnum
 
 
-class Severity(str, Enum):
+class Severity(StrEnum):
 
     Security = 'security'
     Critical = 'critical'
@@ -19,7 +20,7 @@ class Severity(str, Enum):
     Unknown = 'unknown'
 
 
-class Status(str, Enum):
+class Status(StrEnum):
 
     Open = 'open'
     Assign = 'assign'
@@ -32,7 +33,7 @@ class Status(str, Enum):
     Not_Valid = 'notValid'
 
 
-class Action(str, Enum):
+class Action(StrEnum):
 
     OPEN = 'open'
     ASSIGN = 'assign'
@@ -45,7 +46,7 @@ class Action(str, Enum):
     TIMEOUT = 'timeout'
 
 
-class TrendIndication(str, Enum):
+class TrendIndication(StrEnum):
 
     More_Severe = 'moreSevere'
     No_Change = 'noChange'
@@ -143,7 +144,7 @@ class Scope(str):
 ADMIN_SCOPES = [Scope.admin, Scope.read, Scope.write]
 
 
-class ChangeType(str, Enum):
+class ChangeType(StrEnum):
 
     open = 'open'
     assign = 'assign'
@@ -164,7 +165,7 @@ class ChangeType(str, Enum):
     expired = 'expired'
 
 
-class NoteType(str, Enum):
+class NoteType(StrEnum):
 
     alert = 'alert'
     blackout = 'blackout'

--- a/alerta/models/heartbeat.py
+++ b/alerta/models/heartbeat.py
@@ -2,11 +2,11 @@ import os
 import platform
 import sys
 from datetime import datetime
-from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Union
 from uuid import uuid4
 
 from flask import current_app
+from strenum import StrEnum
 
 from alerta.app import db
 from alerta.database.base import Query
@@ -16,7 +16,7 @@ from alerta.utils.response import absolute_url
 JSON = Dict[str, Any]
 
 
-class HeartbeatStatus(str, Enum):
+class HeartbeatStatus(StrEnum):
 
     OK = 'ok'
     Slow = 'slow'

--- a/alerta/models/key.py
+++ b/alerta/models/key.py
@@ -1,7 +1,8 @@
 from datetime import datetime, timedelta
-from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Union
 from uuid import uuid4
+
+from strenum import StrEnum
 
 from alerta.app import db, key_helper
 from alerta.database.base import Query
@@ -12,7 +13,7 @@ from alerta.utils.response import absolute_url
 JSON = Dict[str, Any]
 
 
-class ApiKeyStatus(str, Enum):
+class ApiKeyStatus(StrEnum):
 
     Active = 'active'
     Expired = 'expired'

--- a/alerta/models/user.py
+++ b/alerta/models/user.py
@@ -1,9 +1,9 @@
 from datetime import datetime
-from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Union
 from uuid import uuid4
 
 from flask import current_app
+from strenum import StrEnum
 
 from alerta.app import db
 from alerta.auth import utils
@@ -14,7 +14,7 @@ from alerta.utils.response import absolute_url
 JSON = Dict[str, Any]
 
 
-class UserStatus(str, Enum):
+class UserStatus(StrEnum):
 
     Active = 'active'
     Inactive = 'inactive'

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,6 @@ pytz==2023.3
 PyYAML==6.0
 requests==2.31.0
 requests_hawk==1.2.1
+StrEnum==0.4.15
 sentry-sdk[flask]==1.26.0
 werkzeug==2.3.6


### PR DESCRIPTION
Addresses breaking change in Python 3.11 for `Enum`s with `str` mixins. See https://blog.pecar.me/python-enum for more information on the issue.

Retains compatibility with Python 3.8 by using the `StrEnum` PyPi package rather than the built-in `StrEnum` introduced in 3.11.

This came to my attention when switching from the MongoDB to the PostgreSQL backend under Python 3.11. The JOINs in `get_alerts()` now use the member's name (e.g. `Severity.Minor`) rather than its value (e.g. `minor`) resulting in no alerts showing in the Web UI. The requested changes fix this and likely other issues.