### PR TITLE
fixes issues if last plugin returns none or raises error

### DIFF
--- a/alerta/utils/api.py
+++ b/alerta/utils/api.py
@@ -97,6 +97,7 @@ def process_action(alert: Alert, action: str, text: str, timeout: int = None) ->
     wanted_plugins, wanted_config = plugins.routing(alert)
 
     updated = None
+    alert_was_updated = False
     for plugin in wanted_plugins:
         if alert.is_suppressed:
             break
@@ -119,8 +120,10 @@ def process_action(alert: Alert, action: str, text: str, timeout: int = None) ->
                 alert, action, text, timeout = updated
             elif len(updated) == 3:
                 alert, action, text = updated
+        if updated:
+            alert_was_updated = True
 
-    if updated:
+    if alert_was_updated:
         alert.update_tags(alert.tags)
         alert.attributes = alert.update_attributes(alert.attributes)
 
@@ -132,6 +135,7 @@ def process_note(alert: Alert, text: str) -> Tuple[Alert, str]:
     wanted_plugins, wanted_config = plugins.routing(alert)
 
     updated = None
+    alert_was_updated = False
     for plugin in wanted_plugins:
         try:
             updated = plugin.take_note(alert, text, config=wanted_config)
@@ -149,8 +153,10 @@ def process_note(alert: Alert, text: str) -> Tuple[Alert, str]:
             updated = updated, text
         if isinstance(updated, tuple) and len(updated) == 2:
             alert, text = updated
+        if updated:
+            alert_was_updated = True
 
-    if updated:
+    if alert_was_updated:
         alert.update_tags(alert.tags)
         alert.update_attributes(alert.attributes)
 
@@ -162,6 +168,7 @@ def process_status(alert: Alert, status: str, text: str) -> Tuple[Alert, str, st
     wanted_plugins, wanted_config = plugins.routing(alert)
 
     updated = None
+    alert_was_updated = False
     for plugin in wanted_plugins:
         if alert.is_suppressed:
             break
@@ -177,12 +184,13 @@ def process_status(alert: Alert, status: str, text: str) -> Tuple[Alert, str, st
             else:
                 logging.error(f"Error while running status plugin '{plugin.name}': {str(e)}")
         if updated:
+            alert_was_updated = True
             try:
                 alert, status, text = updated
             except Exception:
                 alert = updated
 
-    if updated:
+    if alert_was_updated:
         alert.update_tags(alert.tags)
         alert.attributes = alert.update_attributes(alert.attributes)
 


### PR DESCRIPTION
**Description**
In a scenario where the last plugin configured returns "None" or raises an error the current flow does not update the alert with the information from earlier plugins.

This is only an issue if the very last plugin returns none or raises. Its similar to #1798 and should also fix the issue #1773

**Changes**
basically just ensure that the loop signal that an update are to occur instead of having the last plugin do it.

**Screenshots**
If it's a UI change add screenshots to demonstrate changes.

**Checklist**
- [X] Pull request is limited to a single purpose
- [X] Code style/formatting is consistent
- [X] All existing tests are passing
- [ ] Added new tests related to change
- [X] No unnecessary whitespace changes

**Collaboration**
When a user creates a pull request from a fork that they own, the user
generally has the authority to decide if other users can commit to the
pull request's compare branch. If the pull request author wants greater
collaboration, they can grant maintainers of the upstream repository
(that is, anyone with push access to the upstream repository) permission
to commit to the pull request's compare branch

See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork

