### PR TITLE
make action plugins "post_process" instead of "pre_process"

### DIFF
--- a/alerta/views/alerts.py
+++ b/alerta/views/alerts.py
@@ -156,8 +156,8 @@ def action_alert(alert_id):
         raise ApiError('not found', 404)
 
     try:
-        alert, action, text, timeout = process_action(alert, action, text, timeout)
         alert = alert.from_action(action, text, timeout)
+        alert, action, text, timeout = process_action(alert, action, text, timeout)
     except RejectException as e:
         write_audit_trail.send(current_app._get_current_object(), event='alert-action-rejected', message=alert.text,
                                user=g.login, customers=g.customers, scopes=g.scopes, resource_id=alert.id, type='alert',


### PR DESCRIPTION
**Description**
Make actions run after the alert has done its status update to the database. Essentially make the action plugins a "post_process" instead of a "pre_process" plugin

Fixes # (issue)

**Changes**
Include a brief summary of changes...

- I have swapped the order, so that whenever an action is executed via the API the alert is updated in the database including setting the updated status (if ack/unack/close/open/expire action) before the alert is sent to the plugins. Today the action is received sent to the plugins (with the previous status) and then once the plugins are done running it updates the status in the alerts (and the database)

**Checklist**
- [X] Pull request is limited to a single purpose
- [X] Code style/formatting is consistent
- [X] All existing tests are passing
- [ ] Added new tests related to change
- [X] No unnecessary whitespace changes

**Collaboration**
When a user creates a pull request from a fork that they own, the user
generally has the authority to decide if other users can commit to the
pull request's compare branch. If the pull request author wants greater
collaboration, they can grant maintainers of the upstream repository
(that is, anyone with push access to the upstream repository) permission
to commit to the pull request's compare branch

See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork

