### PR TITLE
Add SMTP_SKIP_SSL_VERIFY

### DIFF
--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -210,6 +210,7 @@ SMTP_PORT = 587
 MAIL_LOCALHOST = 'localhost'  # mail server to use in HELO/EHLO command
 SMTP_STARTTLS = True
 SMTP_USE_SSL = False
+SMTP_SKIP_SSL_VERIFY = False
 SSL_KEY_FILE = None
 SSL_CERT_FILE = None
 MAIL_FROM = ''  # replace with valid sender address eg you@gmail.com

--- a/alerta/utils/mailer.py
+++ b/alerta/utils/mailer.py
@@ -32,6 +32,7 @@ class Mailer:
 
         self.smtp_use_ssl = app.config['SMTP_USE_SSL']
         self.smtp_starttls = app.config['SMTP_STARTTLS']
+        self.smtp_skip_ssl_verify = app.config['SMTP_SKIP_SSL_VERIFY']
 
     def send_email(self, email: str, subject: str, body: str, mime: str = 'plain') -> None:
 
@@ -47,6 +48,11 @@ class Mailer:
         try:
             # Create ssl context
             ctx = ssl.create_default_context()
+            if self.smtp_skip_ssl_verify:
+                # Disable SSL certificate verification
+                ctx.check_hostname = False
+                ctx.verify_mode = ssl.CERT_NONE
+                
             if self.ssl_key_file and self.ssl_cert_file:
                 # Load client certificates
                 ctx.load_cert_chain(certfile=self.ssl_cert_file, keyfile=self.ssl_key_file)


### PR DESCRIPTION
**Description**
When using a local smtp server with postfix and a self signed cert, SSL/TLS fails due to certificate verification. This change adds the ability to skip ssl certificate verification as part of the smtp server connection.

Fixes # (issue)

**Changes**
Include a brief summary of changes...
- Adds the SMTP_SKIP_SSL_VERIFY config option to skip ssl verification


**Screenshots**
If it's a UI change add screenshots to demonstrate changes.

**Checklist**
- [ ] Pull request is limited to a single purpose
- [ ] Code style/formatting is consistent
- [ ] All existing tests are passing
- [ ] Added new tests related to change
- [ ] No unnecessary whitespace changes

**Collaboration**
When a user creates a pull request from a fork that they own, the user
generally has the authority to decide if other users can commit to the
pull request's compare branch. If the pull request author wants greater
collaboration, they can grant maintainers of the upstream repository
(that is, anyone with push access to the upstream repository) permission
to commit to the pull request's compare branch

See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork

