### PR TITLE
Added sorting on duplicate_count (postgresql) on queries used in Reports UI

### DIFF
--- a/alerta/database/backends/postgres/base.py
+++ b/alerta/database/backends/postgres/base.py
@@ -564,7 +564,7 @@ class Backend(Database):
               FROM alerts, UNNEST (service) svc
              WHERE {where}
           GROUP BY {group}
-          ORDER BY count DESC
+          ORDER BY count DESC, duplicate_count DESC
         """.format(where=query.where, group=group)
         return [
             {
@@ -590,7 +590,7 @@ class Backend(Database):
               FROM topn, UNNEST (service) svc, UNNEST (history) hist
              WHERE hist.type='severity'
           GROUP BY topn.{group}
-          ORDER BY count DESC
+          ORDER BY count DESC, duplicate_count DESC
         """.format(where=query.where, group=group)
         return [
             {


### PR DESCRIPTION
**Description**
Current sorting is on count only, so alerts with high duplicate_count might or might not be listed. This commit addresses that.

**Changes**
Added `, duplicate_count DESC ` to ORDER BY clause

**Screenshots**
If it's a UI change add screenshots to demonstrate changes.

**Checklist**
- [ ] Pull request is limited to a single purpose
- [ ] Code style/formatting is consistent
- [ ] All existing tests are passing
- [ ] Added new tests related to change
- [ ] No unnecessary whitespace changes

**Collaboration**
When a user creates a pull request from a fork that they own, the user
generally has the authority to decide if other users can commit to the
pull request's compare branch. If the pull request author wants greater
collaboration, they can grant maintainers of the upstream repository
(that is, anyone with push access to the upstream repository) permission
to commit to the pull request's compare branch

See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork

