### PR TITLE
Feat: upgraded sentry and allow custom configuration

### DIFF
--- a/alerta/app.py
+++ b/alerta/app.py
@@ -28,8 +28,8 @@ if sentry_config:
     # Expected format: SENTRY_CONFIG="dsn=DSN,environment=ENVIRONMENT,release=RELEASE" etc. (comma-separated)
     sentry_options = dict(item.split('=') for item in sentry_config.split(','))
     sentry_options['integrations'] = [FlaskIntegration()]
-    if "release" not in sentry_options:
-        sentry_options["release"] = __version__
+    if 'release' not in sentry_options:
+        sentry_options['release'] = __version__
     sentry_sdk.init(**sentry_options)
 else:
     # Sentry will read the DSN from SENTRY_DSN environment variable.

--- a/alerta/app.py
+++ b/alerta/app.py
@@ -4,6 +4,7 @@ import sentry_sdk
 from flask import Flask
 from flask_compress import Compress
 from flask_cors import CORS
+from os import getenv
 from sentry_sdk.integrations.flask import FlaskIntegration
 from werkzeug.middleware.proxy_fix import ProxyFix
 
@@ -22,8 +23,17 @@ from alerta.utils.tracing import Tracing
 from alerta.utils.webhook import CustomWebhooks
 from alerta.version import __version__
 
-# Sentry will read the DSN from SENTRY_DSN environment variable.
-sentry_sdk.init(integrations=[FlaskIntegration()], release=__version__)
+sentry_config = getenv('SENTRY_CONFIG')
+if sentry_config:
+    # Expected format: SENTRY_CONFIG="dsn=DSN,environment=ENVIRONMENT,release=RELEASE" etc. (comma-separated)
+    sentry_options = dict(item.split('=') for item in sentry_config.split(','))
+    sentry_options['integrations'] = [FlaskIntegration()]
+    if "release" not in sentry_options:
+        sentry_options["release"] = __version__
+    sentry_sdk.init(**sentry_options)
+else:
+    # Sentry will read the DSN from SENTRY_DSN environment variable.
+    sentry_sdk.init(integrations=[FlaskIntegration()], release=__version__)
 
 config = Config()
 tracing = Tracing()

--- a/alerta/app.py
+++ b/alerta/app.py
@@ -1,10 +1,10 @@
+from os import getenv
 from typing import Any, Dict
 
 import sentry_sdk
 from flask import Flask
 from flask_compress import Compress
 from flask_cors import CORS
-from os import getenv
 from sentry_sdk.integrations.flask import FlaskIntegration
 from werkzeug.middleware.proxy_fix import ProxyFix
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ pytz==2024.1
 PyYAML==6.0.1
 requests==2.31.0
 requests-hawk==1.2.1
-sentry-sdk[flask]==1.45.0
+sentry-sdk[flask]==2.7.1
 StrEnum==0.4.15
 werkzeug==3.0.2


### PR DESCRIPTION
**Description**
An update to the latest Sentry version, but also the option to add sentry configurations via environment variable. The reason is that we need specific config, like ca_certs (for our onprem sentry install) and a few other options.

Fixes # (issue)

**Changes**
Read SENTRY_CONFIG env variable. This splits the csv formattet key/value string into sentry options

its not really possible to do test cases without having a sentry install.. 

**Checklist**
- [X] Pull request is limited to a single purpose
- [X] Code style/formatting is consistent
- [X] All existing tests are passing
- [ ] Added new tests related to change
- [X] No unnecessary whitespace changes

**Collaboration**
When a user creates a pull request from a fork that they own, the user
generally has the authority to decide if other users can commit to the
pull request's compare branch. If the pull request author wants greater
collaboration, they can grant maintainers of the upstream repository
(that is, anyone with push access to the upstream repository) permission
to commit to the pull request's compare branch

See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork

