### PR TITLE
update sql scheme: change keys.count field type from integer to bigint

### DIFF
--- a/alerta/sql/schema.sql
+++ b/alerta/sql/schema.sql
@@ -127,7 +127,7 @@ CREATE TABLE IF NOT EXISTS keys (
     scopes text[],
     text text,
     expire_time timestamp without time zone,
-    count integer,
+    count bigint,
     last_used_time timestamp without time zone,
     customer text
 );


### PR DESCRIPTION
**Description**
Get issue with limitations of integer type for `keys.count` field on Postgres db - reach limit for count of api key uses.


Fixes # (issue)
Example of error:
```bash
2024-08-06 08:38:33,854 - alerta.app[7784]: ERROR - integer out of range
 [in /app/./alerta/exceptions.py:126]
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 1484, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 1469, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/usr/local/lib/python3.9/site-packages/flask_cors/decorator.py", line 128, in wrapped_function
    resp = make_response(f(*args, **kwargs))
  File "/app/./alerta/auth/decorators.py", line 42, in wrapped
    key_info = ApiKey.verify_key(key)
  File "/app/./alerta/models/key.py", line 165, in verify_key
    db.update_key_last_used(key)
  File "/app/./alerta/database/backends/postgres/base.py", line 1065, in update_key_last_used
    return self._updateone(update, (key, key))
  File "/app/./alerta/database/backends/postgres/base.py", line 1632, in _updateone
    cursor.execute(query, vars)
  File "/usr/local/lib/python3.9/site-packages/psycopg2/extras.py", line 312, in execute
    return super().execute(query, vars)
psycopg2.errors.NumericValueOutOfRange: integer out of range
``` 


**Changes**
- alerta/sql/chema.sql:130 changed  from `count integer` to `count bigint`


**Screenshots**
If it's a UI change add screenshots to demonstrate changes.

**Checklist**
- [ ] Pull request is limited to a single purpose
- [ ] Code style/formatting is consistent
- [ ] All existing tests are passing
- [ ] Added new tests related to change
- [ ] No unnecessary whitespace changes

**Collaboration**
When a user creates a pull request from a fork that they own, the user
generally has the authority to decide if other users can commit to the
pull request's compare branch. If the pull request author wants greater
collaboration, they can grant maintainers of the upstream repository
(that is, anyone with push access to the upstream repository) permission
to commit to the pull request's compare branch

See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork

