### PR TITLE
Query more than two fields with Postgres backend

### DIFF
--- a/alerta/database/backends/postgres/queryparser.py
+++ b/alerta/database/backends/postgres/queryparser.py
@@ -16,9 +16,7 @@ class BinaryOperation:
     """takes two or more operands, e.g. and, or"""
 
     def __init__(self, tokens):
-        self.op = tokens[0][1]
-        self.lhs = tokens[0][0]
-        self.rhs = tokens[0][2]
+        self.tokens = tokens
 
 
 class SearchModifier(UnaryOperation):
@@ -30,15 +28,13 @@ class SearchModifier(UnaryOperation):
 class SearchAnd(BinaryOperation):
 
     def __repr__(self):
-        return f'({self.lhs} AND {self.rhs})'
+        return " AND ".join(map(repr, self.tokens[0]))
 
 
 class SearchOr(BinaryOperation):
 
     def __repr__(self):
-        if getattr(self.rhs, 'op', None) == 'NOT':
-            return f'({self.lhs} AND {self.rhs})'
-        return f'({self.lhs} OR {self.rhs})'
+        return " OR ".join(map(repr, self.tokens[0]))
 
 
 class SearchNot(UnaryOperation):
@@ -123,8 +119,8 @@ class SearchTerm:
 LBRACK, RBRACK, LBRACE, RBRACE, TILDE, CARAT = map(Literal, '[]{}~^')
 LPAR, RPAR, COLON, DOT = map(Suppress, '():.')
 
-AND = Keyword('AND') | Literal('&&')
-OR = Keyword('OR') | Literal('||')
+AND = Suppress(Keyword('AND') | Literal('&&'))
+OR = Suppress(Keyword('OR') | Literal('||'))
 NOT = Keyword('NOT') | Literal('!')
 TO = Keyword('TO')
 
@@ -170,8 +166,8 @@ query_expr << infixNotation(clause,
                             [
                                 (required_modifier | prohibit_modifier, 1, opAssoc.RIGHT, SearchModifier),
                                 (NOT.setParseAction(lambda: 'NOT'), 1, opAssoc.RIGHT, SearchNot),
-                                (AND.setParseAction(lambda: 'AND'), 2, opAssoc.LEFT, SearchAnd),
-                                (Optional(OR).setParseAction(lambda: 'OR'), 2, opAssoc.LEFT, SearchOr),
+                                (AND, 2, opAssoc.LEFT, SearchAnd),
+                                (Optional(OR), 2, opAssoc.LEFT, SearchOr),
                             ])
 
 


### PR DESCRIPTION
**Description**
Postgres backend doesn't support more than two parameters in the query.

For example if I request: 
`origin:"myservice" AND severity:"MAJOR" AND _.key:"value2"` Alerta will generate this request `"origin" ~* '\myservice\y' AND"severity" ~* '\yMAJOR\y'` and skip the `_.key:"value2"` part.

If I change the order of the request to ` _.key:"value2" AND origin:"myservice" AND severity:"MAJOR"`, it will generate  `"attributes"::jsonb ->>'key' ~* '\yvalue2\y' AND "origin" ~* '\myservice\y'` skipping the `severity:"MAJOR"` part.

Same behavior with the OR condition where `origin:"myservice" AND severity:"MAJOR" OR !_.key:"valueAAA"` is transformed into `"origin" ~* '\myservice\y' OR "severity" ~* '\yMAJOR\y'`.

Fixes # (issue)
https://github.com/alerta/alerta/issues/1884

**Changes**
Handle multiple AND/OR operators in Postgres query parser.


**Checklist**
- [ ] Pull request is limited to a single purpose
- [ ] Code style/formatting is consistent
- [ ] All existing tests are passing
- [ ] Added new tests related to change
- [ ] No unnecessary whitespace changes


