### PR TITLE
Use a tested base image which is in LTS support period

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-buster
+FROM python:3.9-slim-bookworm
 
 ARG BUILD_DATE
 ARG BUILD_NUMBER


### PR DESCRIPTION
**Description**
Bump the base docker image for better security posture

NOTE: I am not sure about the release process Alerta repo follows. **This change has not been tested in any way**(hopefully the there is a CI to build/test), feel free to let me know any action I need to take to comply with the release process.

**Changes**
- Bump base image to "bookworm"-based version for better security posture

