### PR TITLE
Fix missing self param in database/base.py

### DIFF
--- a/alerta/database/base.py
+++ b/alerta/database/base.py
@@ -211,7 +211,7 @@ class Database(Base):
     def get_environments(self, query=None, page=None, page_size=1000):
         raise NotImplementedError
 
-    def get_environments_count(query: Query = None) -> int:
+    def get_environments_count(self, query: Query = None) -> int:
         raise NotImplementedError
 
     # SERVICES


### PR DESCRIPTION
The [child classes' implementations](https://github.com/alerta/alerta/blob/4ac0106300cd428b26ad4b373cf4a78f55f6b542/alerta/database/backends/mongodb/base.py#L844) have a self param, so I assume this was accidentally left out

This was discovered when I reviewed a CI job for Pyrefly (a type checker for Python), which runs Pyrefly on a number of open source repositories: https://github.com/facebook/pyrefly/pull/3844

**Checklist**
- [x] Pull request is limited to a single purpose
- [x] Code style/formatting is consistent
- [x] All existing tests are passing
- [ ] Added new tests related to change
- [x] No unnecessary whitespace changes

